### PR TITLE
Revert "docs: include complete application structure in README Project Structure section"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,11 @@ KT-Portal is a multi-tenant SaaS client portal for Kre8ivTech, LLC. It serves wh
 
 ## Project Structure
 
-This repository serves as a template and configuration for the KT-Portal application. The complete application structure includes:
-
 ```
 kt-portal/
 ├── CLAUDE.md              # Project-level AI assistant config
-├── CONTRIBUTING.md        # Contribution guidelines
-├── README.md              # This file
 ├── statusline.json        # Status line configuration
-├── package.json           # Node.js dependencies
-├── next.config.js         # Next.js configuration
-├── tailwind.config.js     # Tailwind CSS configuration
-├── tsconfig.json          # TypeScript configuration
-├── vercel.json            # Vercel deployment configuration
-├── middleware.ts          # Next.js middleware for auth
-│
-├── docs/                  # Documentation
+├── docs/
 │   ├── prd.md             # Product Requirements Document
 │   ├── tech.md            # Technical Specification
 │   ├── changelog.md       # Version history
@@ -53,45 +42,6 @@ kt-portal/
 │   ├── scratchpad.md      # Working notes
 │   ├── user-CLAUDE.md     # User-level config template
 │   └── sessions/          # Example session notes
-│
-├── src/                   # Application source code
-│   ├── app/               # Next.js App Router
-│   │   ├── (auth)/        # Auth route group
-│   │   ├── (dashboard)/   # Protected dashboard routes
-│   │   ├── api/           # API routes & webhooks
-│   │   ├── layout.tsx     # Root layout
-│   │   ├── page.tsx       # Landing page
-│   │   └── globals.css    # Global styles
-│   │
-│   ├── components/        # React components
-│   │   ├── ui/            # Shadcn/ui components
-│   │   ├── layout/        # Layout components
-│   │   ├── tickets/       # Ticket feature components
-│   │   └── ...            # Other feature components
-│   │
-│   ├── hooks/             # Custom React hooks
-│   ├── lib/               # Utilities & helpers
-│   │   ├── supabase/      # Supabase client configs
-│   │   └── validators/    # Zod validation schemas
-│   │
-│   ├── types/             # TypeScript types
-│   │   └── database.ts    # Auto-generated from Supabase
-│   │
-│   └── stores/            # Zustand state stores
-│
-├── supabase/              # Supabase configuration
-│   ├── config.toml        # Supabase config
-│   ├── migrations/        # Database migrations
-│   └── functions/         # Supabase Edge Functions
-│
-├── public/                # Static assets
-│   ├── manifest.json      # PWA manifest
-│   └── icons/             # App icons
-│
-├── tests/                 # Test suites
-│   ├── e2e/               # End-to-end tests (Playwright)
-│   └── unit/              # Unit tests (Vitest)
-│
 ├── agents/                # AI Agent definitions
 ├── commands/              # Custom commands
 ├── contexts/              # Context files
@@ -101,8 +51,6 @@ kt-portal/
 ├── rules/                 # Rule files
 └── skills/                # Skill definitions
 ```
-
-> **Note:** The `src/`, `supabase/`, `public/`, and `tests/` directories will be created during application setup. This repository provides the configuration and documentation framework.
 
 ---
 


### PR DESCRIPTION
Reverts Kre8ivTech/client-portal#2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the expanded README "Project Structure" to a concise template-focused layout.
> 
> - Removes detailed app scaffolding (`src/`, `supabase/`, `public/`, `tests/`, Next.js configs) and retains only config/docs/agent directories
> - Drops the note about those directories being created during setup
> - Keeps docs listing under `docs/` and preserves the "Available Agents" section
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6266469230259e7d55fb7cd1f4da7642cf405f37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->