### PR TITLE
feat(tickets): add priority system with response time SLAs

### DIFF
--- a/src/app/dashboard/admin/tickets/page.tsx
+++ b/src/app/dashboard/admin/tickets/page.tsx
@@ -1,0 +1,87 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { StaffTicketList } from '@/components/tickets/staff-ticket-list'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { AlertCircle } from 'lucide-react'
+
+export const metadata = {
+  title: 'Ticket Management | Admin',
+  description: 'Manage and prioritize support tickets',
+}
+
+export default async function AdminTicketsPage() {
+  const supabase = await createServerSupabaseClient()
+
+  // Check auth and role
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return <div>Unauthorized</div>
+  }
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('organization_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) {
+    return <div>Profile not found</div>
+  }
+
+  const p = profile as { organization_id: string | null; role: string }
+  if (!['super_admin', 'staff', 'partner'].includes(p.role)) {
+    return <div>Forbidden - Admin access required</div>
+  }
+
+  // Fetch all tickets with related user data
+  const ticketsQuery = supabase
+    .from('tickets')
+    .select(`
+      *,
+      created_by_user:users!created_by(id, profiles(name)),
+      assigned_to_user:users!assigned_to(id, profiles(name))
+    `)
+
+  if (p.organization_id && p.role !== 'super_admin') {
+    ticketsQuery.eq('organization_id', p.organization_id)
+  }
+
+  const { data: tickets, error } = await ticketsQuery.order('created_at', { ascending: false })
+
+  if (error) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Ticket Management</h1>
+          <p className="text-muted-foreground mt-1">
+            Manage and prioritize support tickets
+          </p>
+        </div>
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>
+            Failed to load tickets: {error.message}
+          </AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Ticket Management</h1>
+        <p className="text-muted-foreground mt-1">
+          Manage and prioritize support tickets by response time SLA
+        </p>
+      </div>
+
+      {/* Staff Ticket List */}
+      <StaffTicketList initialTickets={tickets || []} />
+    </div>
+  )
+}

--- a/src/components/tickets/priority-indicator.tsx
+++ b/src/components/tickets/priority-indicator.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  getPriorityConfig,
+  formatResponseTime,
+  type TicketPriority,
+} from '@/lib/ticket-priority'
+import { cn } from '@/lib/utils'
+import { AlertCircle, Clock } from 'lucide-react'
+
+interface PriorityIndicatorProps {
+  priority: string | null
+  /** Show compact badge without tooltip */
+  compact?: boolean
+  /** Show response time in badge */
+  showResponseTime?: boolean
+  /** Additional class names */
+  className?: string
+}
+
+/**
+ * Color-coded priority indicator with optional response time display
+ */
+export function PriorityIndicator({
+  priority,
+  compact = false,
+  showResponseTime = false,
+  className,
+}: PriorityIndicatorProps) {
+  const config = getPriorityConfig(priority)
+
+  if (compact) {
+    return (
+      <Badge
+        variant="outline"
+        className={cn(
+          config.colors.bg,
+          config.colors.text,
+          config.colors.border,
+          'font-medium capitalize py-0.5',
+          className
+        )}
+      >
+        {config.label}
+      </Badge>
+    )
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className={cn(
+              config.colors.bg,
+              config.colors.text,
+              config.colors.border,
+              'font-medium py-0.5 gap-1.5 cursor-help',
+              className
+            )}
+          >
+            <span
+              className={cn('w-2 h-2 rounded-full', config.colors.dot)}
+              aria-hidden="true"
+            />
+            {config.label}
+            {showResponseTime && (
+              <span className="text-xs opacity-75 ml-1">
+                ({formatResponseTime(config.firstResponseHours)})
+              </span>
+            )}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <div className="space-y-2">
+            <p className="font-medium">{config.label} Priority</p>
+            <p className="text-xs text-muted-foreground">{config.description}</p>
+            <div className="flex flex-col gap-1 text-xs pt-1 border-t">
+              <div className="flex items-center gap-1.5">
+                <Clock className="h-3 w-3" />
+                <span>First Response: {formatResponseTime(config.firstResponseHours)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <AlertCircle className="h-3 w-3" />
+                <span>Resolution: {formatResponseTime(config.resolutionHours)}</span>
+              </div>
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+interface PriorityDotProps {
+  priority: string | null
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+/**
+ * Minimal priority dot indicator for compact displays
+ */
+export function PriorityDot({ priority, size = 'md', className }: PriorityDotProps) {
+  const config = getPriorityConfig(priority)
+
+  const sizes = {
+    sm: 'w-1.5 h-1.5',
+    md: 'w-2 h-2',
+    lg: 'w-3 h-3',
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              'rounded-full inline-block cursor-help',
+              sizes[size],
+              config.colors.dot,
+              className
+            )}
+            aria-label={`${config.label} priority`}
+          />
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <span>{config.label} Priority</span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+interface PrioritySelectItemProps {
+  priority: TicketPriority
+  showDetails?: boolean
+}
+
+/**
+ * Priority display for select dropdowns with optional details
+ */
+export function PrioritySelectItem({
+  priority,
+  showDetails = false,
+}: PrioritySelectItemProps) {
+  const config = getPriorityConfig(priority)
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={cn('w-2 h-2 rounded-full', config.colors.dot)}
+        aria-hidden="true"
+      />
+      <span>{config.label}</span>
+      {showDetails && (
+        <span className="text-xs text-muted-foreground ml-auto">
+          {formatResponseTime(config.firstResponseHours)} response
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/tickets/staff-ticket-list.tsx
+++ b/src/components/tickets/staff-ticket-list.tsx
@@ -1,0 +1,569 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { createClient } from '@/lib/supabase/client'
+import { useRealtimeTickets } from '@/hooks/use-realtime-tickets'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { format, differenceInHours, isPast } from 'date-fns'
+import Link from 'next/link'
+import { Search, X, Filter, Clock, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PriorityIndicator, PriorityDot } from './priority-indicator'
+import {
+  getPriorityConfig,
+  getPrioritiesByUrgency,
+  formatResponseTime,
+  isUrgentPriority,
+  PRIORITY_CONFIG,
+  type TicketPriority,
+} from '@/lib/ticket-priority'
+import { Database } from '@/types/database'
+
+type Ticket = Database['public']['Tables']['tickets']['Row']
+
+interface TicketWithRelations extends Ticket {
+  created_by_user?: {
+    id: string
+    profiles?: { name: string | null } | null
+  } | null
+  assigned_to_user?: {
+    id: string
+    profiles?: { name: string | null } | null
+  } | null
+}
+
+interface StaffTicketListProps {
+  initialTickets: TicketWithRelations[]
+}
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All Statuses' },
+  { value: 'new', label: 'New' },
+  { value: 'open', label: 'Open' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'pending_client', label: 'Pending Client' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'closed', label: 'Closed' },
+]
+
+const PRIORITY_OPTIONS = [
+  { value: 'all', label: 'All Priorities' },
+  { value: 'critical', label: 'Critical' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+]
+
+const ASSIGNMENT_OPTIONS = [
+  { value: 'all', label: 'All Tickets' },
+  { value: 'unassigned', label: 'Unassigned' },
+  { value: 'assigned', label: 'Assigned' },
+]
+
+const STATUS_STYLES: Record<string, string> = {
+  new: 'bg-blue-50 text-blue-700 border-blue-200',
+  open: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  in_progress: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+  pending_client: 'bg-orange-50 text-orange-700 border-orange-200',
+  resolved: 'bg-green-50 text-green-700 border-green-200',
+  closed: 'bg-slate-100 text-slate-600 border-slate-200',
+}
+
+export function StaffTicketList({ initialTickets }: StaffTicketListProps) {
+  const supabase = createClient()
+  useRealtimeTickets()
+
+  const [searchTerm, setSearchTerm] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [priorityFilter, setPriorityFilter] = useState('all')
+  const [assignmentFilter, setAssignmentFilter] = useState('all')
+  const [sortBy, setSortBy] = useState<'priority' | 'created' | 'due'>('priority')
+
+  const { data: tickets, isError, error } = useQuery({
+    queryKey: ['staff-tickets'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('tickets')
+        .select(`
+          *,
+          created_by_user:users!created_by(id, profiles(name)),
+          assigned_to_user:users!assigned_to(id, profiles(name))
+        `)
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return data as TicketWithRelations[]
+    },
+    initialData: initialTickets,
+  })
+
+  // Filter and sort tickets
+  const filteredTickets = useMemo(() => {
+    if (!tickets) return []
+
+    let filtered = tickets.filter((ticket) => {
+      // Search filter
+      const matchesSearch =
+        searchTerm === '' ||
+        ticket.subject.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        ticket.ticket_number.toString().includes(searchTerm) ||
+        ticket.description?.toLowerCase().includes(searchTerm.toLowerCase())
+
+      // Status filter
+      const matchesStatus = statusFilter === 'all' || ticket.status === statusFilter
+
+      // Priority filter
+      const matchesPriority = priorityFilter === 'all' || ticket.priority === priorityFilter
+
+      // Assignment filter
+      const matchesAssignment =
+        assignmentFilter === 'all' ||
+        (assignmentFilter === 'unassigned' && !ticket.assigned_to) ||
+        (assignmentFilter === 'assigned' && ticket.assigned_to)
+
+      return matchesSearch && matchesStatus && matchesPriority && matchesAssignment
+    })
+
+    // Sort tickets
+    filtered.sort((a, b) => {
+      if (sortBy === 'priority') {
+        const priorityOrder: Record<string, number> = {
+          critical: 1,
+          high: 2,
+          medium: 3,
+          low: 4,
+        }
+        const aPriority = priorityOrder[a.priority ?? 'medium'] ?? 3
+        const bPriority = priorityOrder[b.priority ?? 'medium'] ?? 3
+        if (aPriority !== bPriority) return aPriority - bPriority
+        // Secondary sort by created date for same priority
+        return new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime()
+      }
+      if (sortBy === 'due') {
+        if (!a.sla_due_at && !b.sla_due_at) return 0
+        if (!a.sla_due_at) return 1
+        if (!b.sla_due_at) return -1
+        return new Date(a.sla_due_at).getTime() - new Date(b.sla_due_at).getTime()
+      }
+      // Default: created date
+      return new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime()
+    })
+
+    return filtered
+  }, [tickets, searchTerm, statusFilter, priorityFilter, assignmentFilter, sortBy])
+
+  const hasActiveFilters =
+    searchTerm !== '' ||
+    statusFilter !== 'all' ||
+    priorityFilter !== 'all' ||
+    assignmentFilter !== 'all'
+
+  const clearFilters = () => {
+    setSearchTerm('')
+    setStatusFilter('all')
+    setPriorityFilter('all')
+    setAssignmentFilter('all')
+  }
+
+  // Priority summary counts
+  const priorityCounts = useMemo(() => {
+    if (!tickets) return { critical: 0, high: 0, medium: 0, low: 0, total: 0 }
+    const activeTickets = tickets.filter(
+      (t) => !['resolved', 'closed'].includes(t.status ?? '')
+    )
+    return {
+      critical: activeTickets.filter((t) => t.priority === 'critical').length,
+      high: activeTickets.filter((t) => t.priority === 'high').length,
+      medium: activeTickets.filter((t) => t.priority === 'medium').length,
+      low: activeTickets.filter((t) => t.priority === 'low').length,
+      total: activeTickets.length,
+    }
+  }, [tickets])
+
+  if (isError) {
+    return (
+      <div className="rounded-md border border-destructive/50 bg-destructive/5 p-6 text-center">
+        <p className="font-medium text-destructive">Failed to load tickets.</p>
+        <p className="text-sm text-slate-600 mt-1">
+          {error?.message ?? 'Please refresh the page.'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Priority Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <PrioritySummaryCard
+          priority="critical"
+          count={priorityCounts.critical}
+          onClick={() => setPriorityFilter('critical')}
+          isActive={priorityFilter === 'critical'}
+        />
+        <PrioritySummaryCard
+          priority="high"
+          count={priorityCounts.high}
+          onClick={() => setPriorityFilter('high')}
+          isActive={priorityFilter === 'high'}
+        />
+        <PrioritySummaryCard
+          priority="medium"
+          count={priorityCounts.medium}
+          onClick={() => setPriorityFilter('medium')}
+          isActive={priorityFilter === 'medium'}
+        />
+        <PrioritySummaryCard
+          priority="low"
+          count={priorityCounts.low}
+          onClick={() => setPriorityFilter('low')}
+          isActive={priorityFilter === 'low'}
+        />
+        <Card
+          className={cn(
+            'cursor-pointer transition-all',
+            priorityFilter === 'all' && 'ring-2 ring-primary'
+          )}
+          onClick={() => setPriorityFilter('all')}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              All Active
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{priorityCounts.total}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col md:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <Input
+              placeholder="Search by subject, ticket #, or description..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10"
+            />
+          </div>
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger className="w-full md:w-[180px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={priorityFilter} onValueChange={setPriorityFilter}>
+            <SelectTrigger className="w-full md:w-[180px]">
+              <SelectValue placeholder="Priority" />
+            </SelectTrigger>
+            <SelectContent>
+              {PRIORITY_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  <div className="flex items-center gap-2">
+                    {option.value !== 'all' && (
+                      <PriorityDot priority={option.value} size="sm" />
+                    )}
+                    {option.label}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={assignmentFilter} onValueChange={setAssignmentFilter}>
+            <SelectTrigger className="w-full md:w-[180px]">
+              <SelectValue placeholder="Assignment" />
+            </SelectTrigger>
+            <SelectContent>
+              {ASSIGNMENT_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">Sort by:</span>
+            <div className="flex gap-1">
+              <Button
+                variant={sortBy === 'priority' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => setSortBy('priority')}
+              >
+                Priority
+              </Button>
+              <Button
+                variant={sortBy === 'created' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => setSortBy('created')}
+              >
+                Created
+              </Button>
+              <Button
+                variant={sortBy === 'due' ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={() => setSortBy('due')}
+              >
+                Due Date
+              </Button>
+            </div>
+          </div>
+          {hasActiveFilters && (
+            <Button variant="ghost" size="sm" onClick={clearFilters} className="gap-1">
+              <X className="h-4 w-4" />
+              Clear Filters
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Results count */}
+      {hasActiveFilters && (
+        <p className="text-sm text-slate-500">
+          Showing {filteredTickets.length} of {tickets?.length ?? 0} tickets
+        </p>
+      )}
+
+      {/* Priority Legend */}
+      <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground border rounded-lg p-3 bg-muted/30">
+        <span className="font-medium">Response Times:</span>
+        {getPrioritiesByUrgency().map((config) => (
+          <div key={config.value} className="flex items-center gap-1.5">
+            <span className={cn('w-2 h-2 rounded-full', config.colors.dot)} />
+            <span>
+              {config.label}: {formatResponseTime(config.firstResponseHours)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border bg-white shadow-sm overflow-hidden">
+        <Table>
+          <TableHeader className="bg-slate-50">
+            <TableRow>
+              <TableHead className="font-semibold w-[60px]">Priority</TableHead>
+              <TableHead className="font-semibold w-[100px]">ID</TableHead>
+              <TableHead className="font-semibold">Subject</TableHead>
+              <TableHead className="font-semibold">Status</TableHead>
+              <TableHead className="font-semibold">Requester</TableHead>
+              <TableHead className="font-semibold">Assigned To</TableHead>
+              <TableHead className="font-semibold">Due Date</TableHead>
+              <TableHead className="font-semibold text-right">Created</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredTickets.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="h-32 text-center text-slate-500 italic">
+                  {hasActiveFilters ? 'No tickets match your filters.' : 'No tickets found.'}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredTickets.map((ticket) => {
+                const priorityConfig = getPriorityConfig(ticket.priority)
+                const dueStatus = getDueStatus(ticket.sla_due_at)
+                const isActive = !['resolved', 'closed'].includes(ticket.status ?? '')
+
+                return (
+                  <TableRow
+                    key={ticket.id}
+                    className={cn(
+                      'transition-colors',
+                      isActive && isUrgentPriority(ticket.priority) && priorityConfig.colors.row,
+                      isActive && isUrgentPriority(ticket.priority) && priorityConfig.colors.rowHover,
+                      !isActive && 'opacity-60',
+                      !isUrgentPriority(ticket.priority) && 'hover:bg-slate-50'
+                    )}
+                  >
+                    <TableCell>
+                      <PriorityIndicator priority={ticket.priority} />
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-slate-500 uppercase">
+                      #{ticket.ticket_number}
+                    </TableCell>
+                    <TableCell className="font-medium max-w-[300px]">
+                      <Link
+                        href={`/dashboard/tickets/${ticket.id}`}
+                        className="hover:text-primary transition-colors block truncate"
+                      >
+                        {ticket.subject}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={ticket.status} />
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {ticket.created_by_user?.profiles?.name ?? 'Unknown'}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {ticket.assigned_to_user?.profiles?.name ?? (
+                        <span className="text-orange-600 font-medium">Unassigned</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <DueDateBadge dueDate={ticket.sla_due_at} status={ticket.status ?? 'new'} />
+                    </TableCell>
+                    <TableCell className="text-right text-slate-500 text-sm whitespace-nowrap">
+                      {ticket.created_at ? formatDate(ticket.created_at) : '-'}
+                    </TableCell>
+                  </TableRow>
+                )
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+interface PrioritySummaryCardProps {
+  priority: TicketPriority
+  count: number
+  onClick: () => void
+  isActive: boolean
+}
+
+function PrioritySummaryCard({ priority, count, onClick, isActive }: PrioritySummaryCardProps) {
+  const config = PRIORITY_CONFIG[priority]
+
+  return (
+    <Card
+      className={cn(
+        'cursor-pointer transition-all',
+        config.colors.row,
+        config.colors.rowHover,
+        isActive && 'ring-2 ring-primary'
+      )}
+      onClick={onClick}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <span className={cn('w-2 h-2 rounded-full', config.colors.dot)} />
+          {config.label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline gap-2">
+          <p className={cn('text-2xl font-bold', config.colors.text)}>{count}</p>
+          <p className="text-xs text-muted-foreground">
+            {formatResponseTime(config.firstResponseHours)} SLA
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+type DueStatus = 'overdue' | 'due-soon' | 'due-upcoming' | 'on-track' | 'none'
+
+function getDueStatus(dueDate: string | null): DueStatus {
+  if (!dueDate) return 'none'
+
+  const due = new Date(dueDate)
+  const now = new Date()
+
+  if (isPast(due)) return 'overdue'
+
+  const hoursUntilDue = differenceInHours(due, now)
+
+  if (hoursUntilDue <= 4) return 'due-soon'
+  if (hoursUntilDue <= 24) return 'due-upcoming'
+  return 'on-track'
+}
+
+function DueDateBadge({ dueDate, status }: { dueDate: string | null; status: string }) {
+  if (status === 'resolved' || status === 'closed') {
+    return dueDate ? (
+      <span className="text-sm text-slate-400">{formatDate(dueDate)}</span>
+    ) : (
+      <span className="text-sm text-slate-400">-</span>
+    )
+  }
+
+  if (!dueDate) {
+    return <span className="text-sm text-slate-400">No deadline</span>
+  }
+
+  const dueStatus = getDueStatus(dueDate)
+
+  const styles: Record<DueStatus, string> = {
+    overdue: 'bg-red-100 text-red-700 border-red-300',
+    'due-soon': 'bg-orange-100 text-orange-700 border-orange-300',
+    'due-upcoming': 'bg-yellow-100 text-yellow-700 border-yellow-300',
+    'on-track': 'bg-green-100 text-green-700 border-green-300',
+    none: '',
+  }
+
+  const labels: Record<DueStatus, string> = {
+    overdue: 'Overdue',
+    'due-soon': 'Due soon',
+    'due-upcoming': 'Upcoming',
+    'on-track': 'On track',
+    none: '',
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Badge variant="outline" className={cn('text-xs font-medium py-0.5', styles[dueStatus])}>
+        {dueStatus === 'overdue' && <AlertTriangle className="h-3 w-3 mr-1" />}
+        {labels[dueStatus]}
+      </Badge>
+      <span className="text-xs text-slate-500">{formatDate(dueDate)}</span>
+    </div>
+  )
+}
+
+function formatDate(date: string) {
+  try {
+    return format(new Date(date), 'MMM d, yyyy')
+  } catch {
+    return 'Pending'
+  }
+}
+
+function StatusBadge({ status }: { status: Ticket['status'] }) {
+  const safeStatus = status ?? 'new'
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        STATUS_STYLES[safeStatus] ?? STATUS_STYLES.new,
+        'font-medium capitalize py-0.5'
+      )}
+    >
+      {safeStatus.replace('_', ' ')}
+    </Badge>
+  )
+}

--- a/src/lib/ticket-priority.ts
+++ b/src/lib/ticket-priority.ts
@@ -1,0 +1,184 @@
+/**
+ * Ticket Priority Configuration
+ *
+ * Defines response times, colors, and SLA targets for each priority level.
+ */
+
+export const TICKET_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const
+export type TicketPriority = typeof TICKET_PRIORITIES[number]
+
+export interface PriorityConfig {
+  value: TicketPriority
+  label: string
+  description: string
+  /** First response time target in hours */
+  firstResponseHours: number
+  /** Resolution time target in hours */
+  resolutionHours: number
+  /** Display order (lower = higher priority) */
+  order: number
+  /** Color scheme for UI display */
+  colors: {
+    bg: string
+    bgHover: string
+    text: string
+    border: string
+    dot: string
+    row: string
+    rowHover: string
+  }
+}
+
+/**
+ * Priority configuration with response times and color coding
+ *
+ * Response Time SLAs:
+ * - Critical: 1 hour first response, 4 hours resolution
+ * - High: 4 hours first response, 24 hours resolution
+ * - Medium: 8 hours first response, 48 hours resolution
+ * - Low: 24 hours first response, 72 hours resolution
+ */
+export const PRIORITY_CONFIG: Record<TicketPriority, PriorityConfig> = {
+  critical: {
+    value: 'critical',
+    label: 'Critical',
+    description: 'System down, security breach, or major business impact',
+    firstResponseHours: 1,
+    resolutionHours: 4,
+    order: 1,
+    colors: {
+      bg: 'bg-red-100',
+      bgHover: 'hover:bg-red-200',
+      text: 'text-red-700',
+      border: 'border-red-300',
+      dot: 'bg-red-500',
+      row: 'bg-red-50',
+      rowHover: 'hover:bg-red-100',
+    },
+  },
+  high: {
+    value: 'high',
+    label: 'High',
+    description: 'Significant functionality impacted, workaround available',
+    firstResponseHours: 4,
+    resolutionHours: 24,
+    order: 2,
+    colors: {
+      bg: 'bg-orange-100',
+      bgHover: 'hover:bg-orange-200',
+      text: 'text-orange-700',
+      border: 'border-orange-300',
+      dot: 'bg-orange-500',
+      row: 'bg-orange-50',
+      rowHover: 'hover:bg-orange-100',
+    },
+  },
+  medium: {
+    value: 'medium',
+    label: 'Medium',
+    description: 'Standard request with moderate business impact',
+    firstResponseHours: 8,
+    resolutionHours: 48,
+    order: 3,
+    colors: {
+      bg: 'bg-blue-100',
+      bgHover: 'hover:bg-blue-200',
+      text: 'text-blue-700',
+      border: 'border-blue-300',
+      dot: 'bg-blue-500',
+      row: 'bg-blue-50/30',
+      rowHover: 'hover:bg-blue-50',
+    },
+  },
+  low: {
+    value: 'low',
+    label: 'Low',
+    description: 'General inquiry or minor issue with no immediate impact',
+    firstResponseHours: 24,
+    resolutionHours: 72,
+    order: 4,
+    colors: {
+      bg: 'bg-slate-100',
+      bgHover: 'hover:bg-slate-200',
+      text: 'text-slate-600',
+      border: 'border-slate-300',
+      dot: 'bg-slate-400',
+      row: 'bg-slate-50/30',
+      rowHover: 'hover:bg-slate-50',
+    },
+  },
+}
+
+/**
+ * Get priority configuration by value
+ */
+export function getPriorityConfig(priority: string | null): PriorityConfig {
+  const validPriority = priority as TicketPriority
+  return PRIORITY_CONFIG[validPriority] ?? PRIORITY_CONFIG.medium
+}
+
+/**
+ * Get priority options for select dropdowns
+ */
+export function getPriorityOptions() {
+  return Object.values(PRIORITY_CONFIG)
+    .sort((a, b) => a.order - b.order)
+    .map(({ value, label }) => ({ value, label }))
+}
+
+/**
+ * Calculate SLA due date based on priority
+ */
+export function calculateSlaDueDate(
+  priority: TicketPriority,
+  createdAt: Date = new Date()
+): Date {
+  const config = PRIORITY_CONFIG[priority]
+  const dueDate = new Date(createdAt)
+  dueDate.setHours(dueDate.getHours() + config.resolutionHours)
+  return dueDate
+}
+
+/**
+ * Calculate first response due date based on priority
+ */
+export function calculateFirstResponseDue(
+  priority: TicketPriority,
+  createdAt: Date = new Date()
+): Date {
+  const config = PRIORITY_CONFIG[priority]
+  const dueDate = new Date(createdAt)
+  dueDate.setHours(dueDate.getHours() + config.firstResponseHours)
+  return dueDate
+}
+
+/**
+ * Format response time for display
+ */
+export function formatResponseTime(hours: number): string {
+  if (hours < 1) {
+    return `${hours * 60} minutes`
+  }
+  if (hours === 1) {
+    return '1 hour'
+  }
+  if (hours < 24) {
+    return `${hours} hours`
+  }
+  const days = hours / 24
+  return days === 1 ? '1 day' : `${days} days`
+}
+
+/**
+ * Get all priorities sorted by urgency (most urgent first)
+ */
+export function getPrioritiesByUrgency(): PriorityConfig[] {
+  return Object.values(PRIORITY_CONFIG).sort((a, b) => a.order - b.order)
+}
+
+/**
+ * Check if a priority is considered urgent (critical or high)
+ */
+export function isUrgentPriority(priority: string | null): boolean {
+  return priority === 'critical' || priority === 'high'
+}

--- a/src/lib/validators/ticket.ts
+++ b/src/lib/validators/ticket.ts
@@ -1,13 +1,22 @@
 import { z } from 'zod'
+import { TICKET_PRIORITIES } from '@/lib/ticket-priority'
+
+export const ticketPrioritySchema = z.enum(TICKET_PRIORITIES)
 
 export const createTicketSchema = z.object({
   subject: z.string().min(5, { message: 'Subject must be at least 5 characters.' }),
   description: z.string().min(20, { message: 'Description must be at least 20 characters.' }),
-  priority: z.enum(['low', 'medium', 'high', 'critical']),
+  priority: ticketPrioritySchema,
   category: z.string().min(1, { message: 'Please select a category.' }),
 })
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>
+
+export const updateTicketPrioritySchema = z.object({
+  priority: ticketPrioritySchema,
+})
+
+export type UpdateTicketPriorityInput = z.infer<typeof updateTicketPrioritySchema>
 
 export const TICKET_CATEGORIES = [
   { value: 'technical_support', label: 'Technical Support' },

--- a/supabase/migrations/20260202000001_ticket_priority_sla.sql
+++ b/supabase/migrations/20260202000001_ticket_priority_sla.sql
@@ -1,0 +1,164 @@
+-- Migration: Ticket Priority SLA Fields
+-- Description: Add fields for tracking first response SLA and auto-calculating SLA due dates
+-- Date: 2026-02-02
+
+-- =============================================================================
+-- ADD FIRST RESPONSE DUE FIELD
+-- =============================================================================
+
+-- Add first_response_due_at to track when first response is due (based on priority)
+ALTER TABLE tickets
+ADD COLUMN IF NOT EXISTS first_response_due_at TIMESTAMP WITH TIME ZONE;
+
+-- Add comment describing the SLA response time configuration
+COMMENT ON COLUMN tickets.priority IS 'Ticket priority with response time SLAs: critical (1h/4h), high (4h/24h), medium (8h/48h), low (24h/72h)';
+COMMENT ON COLUMN tickets.first_response_due_at IS 'When first response is due based on priority SLA';
+COMMENT ON COLUMN tickets.first_response_at IS 'When first response was actually made';
+COMMENT ON COLUMN tickets.sla_due_at IS 'When ticket resolution is due based on priority SLA';
+
+-- =============================================================================
+-- FUNCTION: Calculate SLA Due Dates Based on Priority
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION calculate_ticket_sla_dates()
+RETURNS TRIGGER AS $$
+DECLARE
+    first_response_hours INT;
+    resolution_hours INT;
+BEGIN
+    -- Only calculate if sla_due_at or first_response_due_at are not already set
+    IF NEW.sla_due_at IS NULL OR NEW.first_response_due_at IS NULL THEN
+        -- Get response times based on priority
+        CASE NEW.priority
+            WHEN 'critical' THEN
+                first_response_hours := 1;
+                resolution_hours := 4;
+            WHEN 'high' THEN
+                first_response_hours := 4;
+                resolution_hours := 24;
+            WHEN 'medium' THEN
+                first_response_hours := 8;
+                resolution_hours := 48;
+            WHEN 'low' THEN
+                first_response_hours := 24;
+                resolution_hours := 72;
+            ELSE
+                first_response_hours := 8;
+                resolution_hours := 48;
+        END CASE;
+
+        -- Set first response due if not already set
+        IF NEW.first_response_due_at IS NULL THEN
+            NEW.first_response_due_at := COALESCE(NEW.created_at, NOW()) + (first_response_hours || ' hours')::INTERVAL;
+        END IF;
+
+        -- Set SLA due date if not already set
+        IF NEW.sla_due_at IS NULL THEN
+            NEW.sla_due_at := COALESCE(NEW.created_at, NOW()) + (resolution_hours || ' hours')::INTERVAL;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- TRIGGER: Auto-calculate SLA dates on insert
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS calculate_ticket_sla_on_insert ON tickets;
+
+CREATE TRIGGER calculate_ticket_sla_on_insert
+    BEFORE INSERT ON tickets
+    FOR EACH ROW
+    EXECUTE FUNCTION calculate_ticket_sla_dates();
+
+-- =============================================================================
+-- FUNCTION: Recalculate SLA on Priority Change
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION recalculate_ticket_sla_on_priority_change()
+RETURNS TRIGGER AS $$
+DECLARE
+    first_response_hours INT;
+    resolution_hours INT;
+BEGIN
+    -- Only recalculate if priority has changed
+    IF OLD.priority IS DISTINCT FROM NEW.priority THEN
+        -- Get new response times based on updated priority
+        CASE NEW.priority
+            WHEN 'critical' THEN
+                first_response_hours := 1;
+                resolution_hours := 4;
+            WHEN 'high' THEN
+                first_response_hours := 4;
+                resolution_hours := 24;
+            WHEN 'medium' THEN
+                first_response_hours := 8;
+                resolution_hours := 48;
+            WHEN 'low' THEN
+                first_response_hours := 24;
+                resolution_hours := 72;
+            ELSE
+                first_response_hours := 8;
+                resolution_hours := 48;
+        END CASE;
+
+        -- Only update first response due if not already responded
+        IF NEW.first_response_at IS NULL THEN
+            NEW.first_response_due_at := NEW.created_at + (first_response_hours || ' hours')::INTERVAL;
+        END IF;
+
+        -- Only update SLA due if not already resolved
+        IF NEW.resolved_at IS NULL THEN
+            NEW.sla_due_at := NEW.created_at + (resolution_hours || ' hours')::INTERVAL;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- TRIGGER: Recalculate SLA on priority update
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS recalculate_ticket_sla_on_priority_update ON tickets;
+
+CREATE TRIGGER recalculate_ticket_sla_on_priority_update
+    BEFORE UPDATE ON tickets
+    FOR EACH ROW
+    EXECUTE FUNCTION recalculate_ticket_sla_on_priority_change();
+
+-- =============================================================================
+-- UPDATE EXISTING TICKETS: Set SLA dates for tickets missing them
+-- =============================================================================
+
+-- Update existing tickets that don't have SLA dates set
+UPDATE tickets
+SET
+    first_response_due_at = CASE priority
+        WHEN 'critical' THEN created_at + INTERVAL '1 hour'
+        WHEN 'high' THEN created_at + INTERVAL '4 hours'
+        WHEN 'medium' THEN created_at + INTERVAL '8 hours'
+        WHEN 'low' THEN created_at + INTERVAL '24 hours'
+        ELSE created_at + INTERVAL '8 hours'
+    END,
+    sla_due_at = CASE priority
+        WHEN 'critical' THEN created_at + INTERVAL '4 hours'
+        WHEN 'high' THEN created_at + INTERVAL '24 hours'
+        WHEN 'medium' THEN created_at + INTERVAL '48 hours'
+        WHEN 'low' THEN created_at + INTERVAL '72 hours'
+        ELSE created_at + INTERVAL '48 hours'
+    END
+WHERE first_response_due_at IS NULL OR sla_due_at IS NULL;
+
+-- =============================================================================
+-- INDEX: For SLA tracking queries
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_tickets_first_response_due ON tickets(first_response_due_at)
+    WHERE first_response_at IS NULL AND status NOT IN ('resolved', 'closed');
+
+CREATE INDEX IF NOT EXISTS idx_tickets_sla_due ON tickets(sla_due_at)
+    WHERE resolved_at IS NULL AND status NOT IN ('resolved', 'closed');


### PR DESCRIPTION
- Add priority configuration with response times for each level:
  - Critical: 1 hour first response, 4 hours resolution
  - High: 4 hours first response, 24 hours resolution
  - Medium: 8 hours first response, 48 hours resolution
  - Low: 24 hours first response, 72 hours resolution

- Create PriorityIndicator component with color-coded badges and tooltips
- Add StaffTicketList component with:
  - Priority summary cards showing ticket counts per priority
  - Filterable table by status, priority, and assignment
  - Sortable by priority, created date, or due date
  - Color-coded priority rows for urgent tickets
  - Response time SLA legend

- Create admin tickets page at /dashboard/admin/tickets
- Add database migration for automatic SLA calculation:
  - New first_response_due_at field
  - Trigger to auto-calculate SLA dates on ticket creation
  - Trigger to recalculate SLA on priority change

- Update Zod validators to use priority configuration

https://claude.ai/code/session_015B389XiognWJvevAN8pzcx