### PR TITLE
Display human-readable category labels in ticket details

### DIFF
--- a/src/components/tickets/ticket-detail.tsx
+++ b/src/components/tickets/ticket-detail.tsx
@@ -11,6 +11,7 @@ import { format } from 'date-fns'
 import { Calendar, User, Tag, Clock, ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { Database } from '@/types/database'
+import { TICKET_CATEGORIES } from '@/lib/validators/ticket'
 
 type Ticket = Database['public']['Tables']['tickets']['Row'] & {
   creator?: {
@@ -127,10 +128,10 @@ export function TicketDetail({ ticket: initialTicket, userId, userRole }: Ticket
               value={ticket.sla_due_at ? format(new Date(ticket.sla_due_at), 'MMM d, yyyy') : 'No deadline'} 
             />
             
-            <DetailItem 
-              icon={<Tag className="h-4 w-4 text-slate-400" />} 
-              label="Category" 
-              value={ticket.category || 'Uncategorized'} 
+            <DetailItem
+              icon={<Tag className="h-4 w-4 text-slate-400" />}
+              label="Category"
+              value={getCategoryLabel(ticket.category)}
             />
 
             {canAssign ? (
@@ -223,4 +224,10 @@ function PriorityBadge({ priority }: { priority: Ticket['priority'] }) {
       {priority}
     </Badge>
   )
+}
+
+function getCategoryLabel(category: string | null): string {
+  if (!category) return 'Uncategorized'
+  const found = TICKET_CATEGORIES.find((c) => c.value === category)
+  return found ? found.label : category.replace(/_/g, ' ')
 }


### PR DESCRIPTION
## Summary
Updated the ticket detail view to display human-readable category labels instead of raw category values by introducing a new `getCategoryLabel` helper function that maps category codes to their display labels.

## Changes
- Added import of `TICKET_CATEGORIES` from the ticket validators module
- Created `getCategoryLabel()` helper function that:
  - Returns 'Uncategorized' for null/empty categories
  - Looks up the category in `TICKET_CATEGORIES` to find the human-readable label
  - Falls back to converting underscores to spaces if no match is found
- Updated the Category DetailItem to use `getCategoryLabel()` instead of displaying the raw category value
- Minor formatting cleanup (whitespace normalization in the DetailItem component)

## Implementation Details
The `getCategoryLabel()` function provides a robust fallback mechanism to handle edge cases where a category value might not exist in the `TICKET_CATEGORIES` list, ensuring the UI always displays something meaningful to users rather than raw database values.

https://claude.ai/code/session_016Gw6dNikjjB5r6R2bX5M5L