### PR TITLE
New contracts 404 error

### DIFF
--- a/src/app/api/contracts/[id]/route.ts
+++ b/src/app/api/contracts/[id]/route.ts
@@ -130,12 +130,12 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (input.metadata && existingContract.template_id) {
       const { data: template } = await (supabase as any)
         .from('contract_templates')
-        .select('content')
+        .select('template_content')
         .eq('id', existingContract.template_id)
         .single()
 
-      if (template?.content) {
-        content_html = template.content
+      if (template?.template_content) {
+        content_html = template.template_content
         const mergedMetadata = { ...existingContract.metadata, ...input.metadata }
         Object.entries(mergedMetadata).forEach(([key, value]) => {
           const regex = new RegExp(`{{\\s*${key}\\s*}}`, 'g')

--- a/src/app/api/contracts/route.ts
+++ b/src/app/api/contracts/route.ts
@@ -195,7 +195,7 @@ export async function POST(request: NextRequest) {
       }
 
       // Basic template rendering - replace {{variable}} with values
-      content_html = template.content
+      content_html = template.template_content
       if (content_html && content_data) {
         Object.entries(content_data).forEach(([key, value]) => {
           const regex = new RegExp(`{{\\s*${key}\\s*}}`, 'g')

--- a/src/lib/actions/contracts.ts
+++ b/src/lib/actions/contracts.ts
@@ -88,9 +88,9 @@ export async function createContractFromTemplate(
         description: metadata.description || template.description,
         contract_type: template.contract_type,
         status: 'draft',
+        content_html: contractContent,
         metadata: {
           ...metadata,
-          template_content: contractContent,
           variables: metadata
         }
       })

--- a/supabase/migrations/20260203000004_add_contracts_content_html.sql
+++ b/supabase/migrations/20260203000004_add_contracts_content_html.sql
@@ -1,0 +1,15 @@
+-- Migration: Add content_html field to contracts table
+-- Description: Fix missing content_html field that was causing 404 errors when viewing contracts
+-- Date: 2026-02-03
+
+-- Add content_html column to contracts table
+ALTER TABLE contracts
+ADD COLUMN IF NOT EXISTS content_html TEXT;
+
+-- Add index for text search if needed in the future
+CREATE INDEX IF NOT EXISTS idx_contracts_content_html ON contracts USING gin(to_tsvector('english', content_html)) WHERE content_html IS NOT NULL;
+
+-- Migrate existing metadata.template_content to content_html
+UPDATE contracts
+SET content_html = metadata->>'template_content'
+WHERE metadata ? 'template_content' AND content_html IS NULL;


### PR DESCRIPTION
Add `content_html` column to the `contracts` table and update contract creation/API routes to resolve 404 errors when setting up new contracts.

The application code expected a `content_html` field in the `contracts` table, but it was missing, leading to 404 errors. Additionally, some API routes were using an incorrect field name (`template.content` instead of `template.template_content`) when retrieving template data. This PR addresses both issues by adding the missing column, migrating existing data, and correcting the field references in the application and API code.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dd17a52-daf0-4402-966d-15148d50c8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dd17a52-daf0-4402-966d-15148d50c8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

