### PR TITLE
Settings links navigation

### DIFF
--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -1,0 +1,108 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Bell } from "lucide-react";
+
+export default async function NotificationsSettingsPage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">Notification Settings</h2>
+        <p className="text-muted-foreground mt-2">
+          Manage how and when you receive notifications.
+        </p>
+      </div>
+
+      <div className="grid gap-8">
+        <Card className="border-border shadow-sm overflow-hidden">
+          <CardHeader className="bg-muted/30 border-b">
+            <CardTitle className="text-lg font-semibold flex items-center gap-2">
+              <Bell className="text-primary w-5 h-5" />
+              Email Notifications
+            </CardTitle>
+            <CardDescription>
+              Choose which email notifications you want to receive.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="ticket-updates">Ticket Updates</Label>
+                <p className="text-sm text-muted-foreground">
+                  Receive notifications when tickets are updated
+                </p>
+              </div>
+              <Switch id="ticket-updates" defaultChecked />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="invoice-reminders">Invoice Reminders</Label>
+                <p className="text-sm text-muted-foreground">
+                  Get reminders about upcoming or overdue invoices
+                </p>
+              </div>
+              <Switch id="invoice-reminders" defaultChecked />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="new-messages">New Messages</Label>
+                <p className="text-sm text-muted-foreground">
+                  Notification when you receive new messages
+                </p>
+              </div>
+              <Switch id="new-messages" defaultChecked />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="contract-updates">Contract Updates</Label>
+                <p className="text-sm text-muted-foreground">
+                  Updates about contract status and renewals
+                </p>
+              </div>
+              <Switch id="contract-updates" defaultChecked />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border shadow-sm overflow-hidden">
+          <CardHeader className="bg-muted/30 border-b">
+            <CardTitle className="text-lg font-semibold flex items-center gap-2">
+              <Bell className="text-primary w-5 h-5" />
+              In-App Notifications
+            </CardTitle>
+            <CardDescription>
+              Manage notifications that appear within the application.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="push-notifications">Push Notifications</Label>
+                <p className="text-sm text-muted-foreground">
+                  Receive browser push notifications
+                </p>
+              </div>
+              <Switch id="push-notifications" />
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="sound-alerts">Sound Alerts</Label>
+                <p className="text-sm text-muted-foreground">
+                  Play a sound when receiving notifications
+                </p>
+              </div>
+              <Switch id="sound-alerts" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,14 +1,8 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Globe, Palette, ShieldCheck } from "lucide-react";
+import { Settings } from "lucide-react";
 import { CalendarOfficeHours } from "@/components/settings/calendar-office-hours";
-import { PortalBrandingForm } from "@/components/settings/portal-branding-form";
 import { AdminAccessInfo } from "@/components/settings/admin-access-info";
-import { SecuritySettings } from "@/components/settings/security-settings";
-import { getPortalBranding } from "@/lib/actions/portal-branding";
 
 export default async function SettingsPage() {
   const supabase = await createServerSupabaseClient();
@@ -17,117 +11,57 @@ export default async function SettingsPage() {
   } = await supabase.auth.getUser();
   if (!user) return null;
 
-  const [
-    { data: userData },
-    { data: profileData },
-    { data: orgData }
-  ] = await Promise.all([
-    supabase.from("users").select("id, role, organization_id").eq("id", user.id).single(),
-    supabase.from("user_profiles").select("id, name, avatar_url, organization_name, organization_slug").eq("id", user.id).single(),
-    supabase.from("organizations").select("id, settings").eq("id", user?.user_metadata?.organization_id || user?.id /* fallback if needed, though organization_id should exist */).single() // logic check below
-  ]);
+  const { data: userData } = await supabase
+    .from("users")
+    .select("id, role, organization_id")
+    .eq("id", user.id)
+    .single();
 
-  // Fix organization fetch logic
   const userRow = userData as { id: string; role: string; organization_id: string | null } | null;
-  const organizationId = userRow?.organization_id;
-  let organizationSettings = {};
-  
-  if (organizationId) {
-     const { data: org } = await supabase.from("organizations").select("settings").eq("id", organizationId).single();
-     const orgData = org as { settings: any } | null;
-     organizationSettings = orgData?.settings || {};
-  }
-
-  const profileRow = profileData as { id: string; name: string | null; avatar_url: string | null; organization_name: string | null; organization_slug: string | null } | null;
-  const profile =
-    userRow && profileRow
-      ? {
-          id: userRow.id,
-          role: userRow.role,
-          name: profileRow.name,
-          avatar_url: profileRow.avatar_url,
-          organization_name: profileRow.organization_name,
-          organization_slug: profileRow.organization_slug,
-        }
-      : null;
-  const organization = profile ? { name: profile.organization_name, slug: profile.organization_slug } : null;
-  const role = profile?.role ?? "client";
+  const role = userRow?.role ?? "client";
   const isStaffOrAdmin = role === "staff" || role === "super_admin";
   const isSuperAdmin = role === "super_admin";
-  const isPartner = role === "partner" || role === "partner_staff";
-  const canSeeBranding = isStaffOrAdmin || isPartner; // Admin, staff, and partners can see branding
-  const portalBranding = isSuperAdmin ? await getPortalBranding() : null;
 
   return (
     <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div>
-        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">Settings</h2>
+        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">General Settings</h2>
         <p className="text-muted-foreground mt-2">
-          Manage your organization and portal-wide configurations.
+          Manage your general account and system settings.
         </p>
       </div>
 
       <div className="grid gap-8">
-        {/* Admin: how admin login works + portal branding */}
-        {isSuperAdmin && (
-          <>
-            <AdminAccessInfo />
-            {portalBranding && <PortalBrandingForm branding={portalBranding} />}
-          </>
-        )}
+        {/* Admin: how admin login works */}
+        {isSuperAdmin && <AdminAccessInfo />}
 
         {/* Calendar & Office Hours - Staff/Admin only */}
         {isStaffOrAdmin && <CalendarOfficeHours profileId={user.id} />}
 
-        {/* Organization branding - admin/staff/partners only (NOT clients) */}
-        {canSeeBranding && !isSuperAdmin && (
-          <Card id="white-label" className="border-border shadow-sm overflow-hidden scroll-mt-20">
-            <CardHeader className="bg-muted/30 border-b">
-              <CardTitle className="text-lg font-semibold flex items-center gap-2">
-                <Palette className="text-primary w-5 h-5" />
-                Organization Branding
-              </CardTitle>
-              <CardDescription>
-                Customize the look and feel of your organization (contact admin for portal-wide changes).
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="pt-6 space-y-6">
-              <div className="grid gap-6 sm:grid-cols-2">
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label>Organization Name</Label>
-                    <Input defaultValue={organization?.name ?? ""} className="bg-background" readOnly />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Primary Color</Label>
-                    <div className="flex gap-2">
-                      <Input defaultValue="#556ee6" className="bg-background" readOnly />
-                      <div className="h-10 w-10 shrink-0 rounded-md border border-border bg-primary" />
-                    </div>
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  <Label>Logo</Label>
-                  <div className="h-32 border-2 border-dashed border-border rounded-lg flex flex-col items-center justify-center text-muted-foreground bg-muted/30">
-                    <Globe size={24} className="mb-2 opacity-20" />
-                    <p className="text-xs">Portal branding is managed by the administrator.</p>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Security / System Section */}
-        {organizationId && (isStaffOrAdmin || isPartner) && (
-          // @ts-ignore
-          <SecuritySettings 
-            organizationId={organizationId} 
-            // @ts-ignore
-            settings={organizationSettings?.security} 
-          />
-        )}
+        {/* General settings placeholder for all users */}
+        <Card className="border-border shadow-sm overflow-hidden">
+          <CardHeader className="bg-muted/30 border-b">
+            <CardTitle className="text-lg font-semibold flex items-center gap-2">
+              <Settings className="text-primary w-5 h-5" />
+              General Preferences
+            </CardTitle>
+            <CardDescription>
+              Configure your general account preferences.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="pt-6 space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Additional settings can be found in the navigation menu:
+            </p>
+            <ul className="list-disc list-inside space-y-2 text-sm text-muted-foreground">
+              <li>White Label - Customize portal branding</li>
+              <li>Security - Manage security and authentication settings</li>
+              <li>Notifications - Configure notification preferences</li>
+              <li>Integrations - Connect third-party services</li>
+            </ul>
+          </CardContent>
+        </Card>
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/dashboard/settings/security/page.tsx
+++ b/src/app/dashboard/settings/security/page.tsx
@@ -1,0 +1,58 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { SecuritySettings } from "@/components/settings/security-settings";
+import { redirect } from "next/navigation";
+
+export default async function SecuritySettingsPage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: userData } = await supabase
+    .from("users")
+    .select("id, role, organization_id")
+    .eq("id", user.id)
+    .single();
+
+  const userRow = userData as { id: string; role: string; organization_id: string | null } | null;
+  const role = userRow?.role ?? "client";
+  const organizationId = userRow?.organization_id;
+  const isStaffOrAdmin = role === "staff" || role === "super_admin";
+  const isPartner = role === "partner" || role === "partner_staff";
+
+  // If user doesn't have access to security settings, redirect to general settings
+  if (!organizationId || (!isStaffOrAdmin && !isPartner)) {
+    redirect("/dashboard/settings");
+  }
+
+  // Get organization settings
+  const { data: org } = await supabase
+    .from("organizations")
+    .select("settings")
+    .eq("id", organizationId)
+    .single();
+  
+  const orgData = org as { settings: any } | null;
+  const organizationSettings = orgData?.settings || {};
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">Security Settings</h2>
+        <p className="text-muted-foreground mt-2">
+          Manage security and authentication settings for your organization.
+        </p>
+      </div>
+
+      <div className="grid gap-8">
+        {/* @ts-ignore */}
+        <SecuritySettings 
+          organizationId={organizationId} 
+          // @ts-ignore
+          settings={organizationSettings?.security} 
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/settings/white-label/page.tsx
+++ b/src/app/dashboard/settings/white-label/page.tsx
@@ -1,0 +1,112 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Globe, Palette } from "lucide-react";
+import { PortalBrandingForm } from "@/components/settings/portal-branding-form";
+import { getPortalBranding } from "@/lib/actions/portal-branding";
+import { redirect } from "next/navigation";
+
+export default async function WhiteLabelSettingsPage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: userData } = await supabase
+    .from("users")
+    .select("id, role, organization_id")
+    .eq("id", user.id)
+    .single();
+
+  const { data: profileData } = await supabase
+    .from("user_profiles")
+    .select("id, name, avatar_url, organization_name, organization_slug")
+    .eq("id", user.id)
+    .single();
+
+  const userRow = userData as { id: string; role: string; organization_id: string | null } | null;
+  const profileRow = profileData as { id: string; name: string | null; avatar_url: string | null; organization_name: string | null; organization_slug: string | null } | null;
+  
+  const profile =
+    userRow && profileRow
+      ? {
+          id: userRow.id,
+          role: userRow.role,
+          name: profileRow.name,
+          avatar_url: profileRow.avatar_url,
+          organization_name: profileRow.organization_name,
+          organization_slug: profileRow.organization_slug,
+        }
+      : null;
+
+  const organization = profile ? { name: profile.organization_name, slug: profile.organization_slug } : null;
+  const role = profile?.role ?? "client";
+  const isSuperAdmin = role === "super_admin";
+  const isStaffOrAdmin = role === "staff" || role === "super_admin";
+  const isPartner = role === "partner" || role === "partner_staff";
+  const canSeeBranding = isStaffOrAdmin || isPartner;
+
+  // If user doesn't have access to branding, redirect to general settings
+  if (!canSeeBranding) {
+    redirect("/dashboard/settings");
+  }
+
+  const portalBranding = isSuperAdmin ? await getPortalBranding() : null;
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">White Label Settings</h2>
+        <p className="text-muted-foreground mt-2">
+          Customize the look and feel of your portal.
+        </p>
+      </div>
+
+      <div className="grid gap-8">
+        {/* Super Admin: Portal-wide branding */}
+        {isSuperAdmin && portalBranding && <PortalBrandingForm branding={portalBranding} />}
+
+        {/* Organization branding - admin/staff/partners (NOT super_admin, NOT clients) */}
+        {canSeeBranding && !isSuperAdmin && (
+          <Card className="border-border shadow-sm overflow-hidden">
+            <CardHeader className="bg-muted/30 border-b">
+              <CardTitle className="text-lg font-semibold flex items-center gap-2">
+                <Palette className="text-primary w-5 h-5" />
+                Organization Branding
+              </CardTitle>
+              <CardDescription>
+                Customize the look and feel of your organization (contact admin for portal-wide changes).
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="pt-6 space-y-6">
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label>Organization Name</Label>
+                    <Input defaultValue={organization?.name ?? ""} className="bg-background" readOnly />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Primary Color</Label>
+                    <div className="flex gap-2">
+                      <Input defaultValue="#556ee6" className="bg-background" readOnly />
+                      <div className="h-10 w-10 shrink-0 rounded-md border border-border bg-primary" />
+                    </div>
+                  </div>
+                </div>
+                <div className="space-y-4">
+                  <Label>Logo</Label>
+                  <div className="h-32 border-2 border-dashed border-border rounded-lg flex flex-col items-center justify-center text-muted-foreground bg-muted/30">
+                    <Globe size={24} className="mb-2 opacity-20" />
+                    <p className="text-xs">Portal branding is managed by the administrator.</p>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   Home,
@@ -79,9 +78,9 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     label: "Settings",
     items: [
       { href: "/dashboard/settings", icon: Settings, label: "General" },
-      { href: "/dashboard/settings#white-label", icon: Palette, label: "White Label" },
-      { href: "/dashboard/settings#security", icon: Shield, label: "Security" },
-      { href: "/dashboard/settings#notifications", icon: Bell, label: "Notifications" },
+      { href: "/dashboard/settings/white-label", icon: Palette, label: "White Label" },
+      { href: "/dashboard/settings/security", icon: Shield, label: "Security" },
+      { href: "/dashboard/settings/notifications", icon: Bell, label: "Notifications" },
       { href: "/dashboard/integrations", icon: Plug, label: "Integrations" },
     ],
   },
@@ -118,13 +117,13 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
     "/dashboard/settings",
     "/dashboard/vault",
     "/dashboard/billing",
-    "/dashboard/settings#security",
+    "/dashboard/settings/security",
     "/dashboard/profile",
-    "/dashboard/settings#notifications",
+    "/dashboard/settings/notifications",
   ];
   // Account items without invoices (for non-account-manager staff)
   const accountBaseNoInvoices = accountBase.filter(href => href !== "/dashboard/invoices");
-  const whiteLabel = "/dashboard/settings#white-label";
+  const whiteLabel = "/dashboard/settings/white-label";
   const adminStaff = [
     "/dashboard/users",
     "/dashboard/plans",
@@ -206,15 +205,6 @@ export function DashboardSidebar({
   branding?: SidebarBranding | null;
 }) {
   const pathname = usePathname();
-  const [hash, setHash] = useState("");
-
-  // Track hash changes for proper active state on hash-based navigation
-  useEffect(() => {
-    const updateHash = () => setHash(window.location.hash);
-    updateHash();
-    window.addEventListener("hashchange", updateHash);
-    return () => window.removeEventListener("hashchange", updateHash);
-  }, []);
 
   // Admin links (e.g. Clients) require profile.role === "super_admin". Ensure profile is loaded (RLS: "Users can read their own profile").
   const role = profile?.role ?? "client";
@@ -275,22 +265,16 @@ export function DashboardSidebar({
               </p>
               <ul className="space-y-0.5">
                 {items.map((item) => {
-                  const [itemPath, itemHash] = item.href.split("#");
-
                   let isActive = false;
-                  if (itemHash) {
-                    // Hash-based route: must match path AND hash exactly
-                    isActive = pathname === itemPath && hash === `#${itemHash}`;
-                  } else if (item.href === "/dashboard") {
-                    // Dashboard home: exact match only, no hash
-                    isActive = pathname === "/dashboard" && !hash;
-                  } else if (pathname === itemPath) {
-                    // Exact path match with no hash in the item
-                    // Only active if there's no hash in the URL, or if it's not a settings page
-                    isActive = itemPath !== "/dashboard/settings" || !hash;
+                  if (item.href === "/dashboard") {
+                    // Dashboard home: exact match only
+                    isActive = pathname === "/dashboard";
+                  } else if (pathname === item.href) {
+                    // Exact path match
+                    isActive = true;
                   } else {
-                    // Nested route: startsWith but not for items that have hash siblings
-                    isActive = pathname.startsWith(itemPath + "/");
+                    // Nested route: check if current path starts with item path
+                    isActive = pathname.startsWith(item.href + "/");
                   }
                   return (
                     <li key={item.href}>


### PR DESCRIPTION
Refactor settings navigation to use separate pages instead of hash-based scrolling to improve user experience and routing.

The previous implementation used hash fragments (e.g., `#white-label`) to navigate between different sections within the `/dashboard/settings` page. This approach did not provide distinct URLs for each settings area, making it difficult to bookmark, share, or directly access specific settings. This PR introduces dedicated pages for White Label, Security, and Notifications settings, each with its own route, and updates the sidebar navigation accordingly. This also includes refactoring the main `/dashboard/settings` page to focus on general settings and provide links to the new dedicated pages, along with appropriate role-based access control for the new routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc1e0261-c007-4eb5-9310-593d52fa9d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc1e0261-c007-4eb5-9310-593d52fa9d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

