### PR TITLE
Profile layout wrapping

### DIFF
--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -66,9 +66,9 @@ export default function ProfilePage() {
         </p>
       </div>
 
-      <div className="space-y-8">
-        {/* Personal Info Section */}
-        <Card className="border-slate-200 shadow-sm overflow-hidden bg-white/50 backdrop-blur-sm">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Personal Info Section - Full Width */}
+        <Card className="border-slate-200 shadow-sm overflow-hidden bg-white/50 backdrop-blur-sm lg:col-span-2">
           <CardHeader className="bg-slate-50/50 border-b border-slate-100">
             <CardTitle className="text-lg font-semibold flex items-center gap-2">
               <User className="text-primary w-5 h-5" />


### PR DESCRIPTION
Update `/dashboard/profile` layout to use a responsive grid with wrapping cards.

The profile page now uses a responsive grid (`grid grid-cols-1 lg:grid-cols-2 gap-6`) instead of a vertical stack (`space-y-8`), allowing cards to wrap based on screen size and improving the use of horizontal space on larger screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-90bd6c1d-3cb6-4d5b-9ce2-404f99896cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90bd6c1d-3cb6-4d5b-9ce2-404f99896cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

