### PR TITLE
Html encoding sniffer import

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "docusign-esign": "^8.5.0",
-    "isomorphic-dompurify": "^2.35.0",
+    "isomorphic-dompurify": "2.26.0",
     "langchain": "^1.2.16",
     "lucide-react": "^0.474.0",
     "next": "^16.1.6",
@@ -73,6 +73,8 @@
     "typescript": "^5"
   },
   "overrides": {
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "jsdom": "26.1.0",
+    "html-encoding-sniffer": "4.0.0"
   }
 }


### PR DESCRIPTION
Pin `isomorphic-dompurify` and add `overrides` to prevent `ERR_REQUIRE_ESM` from `html-encoding-sniffer`.

The `ERR_REQUIRE_ESM` error occurred because `html-encoding-sniffer@6` (pulled by `jsdom@27`, a transitive dependency of `isomorphic-dompurify@2.35.0`) attempts to `require()` an ESM-only file in a CommonJS context. This PR downgrades `isomorphic-dompurify` to `2.26.0` and uses `overrides` to ensure `jsdom@26.1.0` and `html-encoding-sniffer@4.0.0` are used, which are compatible with CommonJS environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d9f1709-275b-46e7-9fc3-95937237438e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d9f1709-275b-46e7-9fc3-95937237438e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

