### PR TITLE
fix(white-label): allow partners to edit organization branding

### DIFF
--- a/src/app/dashboard/settings/white-label/page.tsx
+++ b/src/app/dashboard/settings/white-label/page.tsx
@@ -1,9 +1,6 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Globe, Palette } from "lucide-react";
 import { PortalBrandingForm } from "@/components/settings/portal-branding-form";
+import { OrganizationBrandingForm } from "@/components/settings/organization-branding-form";
 import { getPortalBranding } from "@/lib/actions/portal-branding";
 import { redirect } from "next/navigation";
 
@@ -28,7 +25,7 @@ export default async function WhiteLabelSettingsPage() {
 
   const userRow = userData as { id: string; role: string; organization_id: string | null } | null;
   const profileRow = profileData as { id: string; name: string | null; avatar_url: string | null; organization_name: string | null; organization_slug: string | null } | null;
-  
+
   const profile =
     userRow && profileRow
       ? {
@@ -41,7 +38,23 @@ export default async function WhiteLabelSettingsPage() {
         }
       : null;
 
-  const organization = profile ? { name: profile.organization_name, slug: profile.organization_slug } : null;
+  // Fetch the full organization with branding_config for partners
+  type OrganizationRow = {
+    id: string;
+    name: string;
+    slug: string;
+    type: string;
+    branding_config: { logo_url?: string | null; primary_color?: string | null } | null;
+  };
+  let organization: OrganizationRow | null = null;
+  if (userRow?.organization_id) {
+    const { data: orgData } = await supabase
+      .from("organizations")
+      .select("id, name, slug, type, branding_config")
+      .eq("id", userRow.organization_id)
+      .single();
+    organization = orgData as OrganizationRow | null;
+  }
   const role = profile?.role ?? "client";
   const isSuperAdmin = role === "super_admin";
   const isStaffOrAdmin = role === "staff" || role === "super_admin";
@@ -68,43 +81,12 @@ export default async function WhiteLabelSettingsPage() {
         {/* Super Admin: Portal-wide branding */}
         {isSuperAdmin && portalBranding && <PortalBrandingForm branding={portalBranding} />}
 
-        {/* Organization branding - admin/staff/partners (NOT super_admin, NOT clients) */}
-        {canSeeBranding && !isSuperAdmin && (
-          <Card className="border-border shadow-sm overflow-hidden">
-            <CardHeader className="bg-muted/30 border-b">
-              <CardTitle className="text-lg font-semibold flex items-center gap-2">
-                <Palette className="text-primary w-5 h-5" />
-                Organization Branding
-              </CardTitle>
-              <CardDescription>
-                Customize the look and feel of your organization (contact admin for portal-wide changes).
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="pt-6 space-y-6">
-              <div className="grid gap-6 sm:grid-cols-2">
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label>Organization Name</Label>
-                    <Input defaultValue={organization?.name ?? ""} className="bg-background" readOnly />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>Primary Color</Label>
-                    <div className="flex gap-2">
-                      <Input defaultValue="#556ee6" className="bg-background" readOnly />
-                      <div className="h-10 w-10 shrink-0 rounded-md border border-border bg-primary" />
-                    </div>
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  <Label>Logo</Label>
-                  <div className="h-32 border-2 border-dashed border-border rounded-lg flex flex-col items-center justify-center text-muted-foreground bg-muted/30">
-                    <Globe size={24} className="mb-2 opacity-20" />
-                    <p className="text-xs">Portal branding is managed by the administrator.</p>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        {/* Organization branding - partners can edit their own branding */}
+        {canSeeBranding && !isSuperAdmin && organization && (
+          <OrganizationBrandingForm
+            organization={organization}
+            canEdit={isPartner}
+          />
         )}
       </div>
     </div>

--- a/src/components/settings/organization-branding-form.tsx
+++ b/src/components/settings/organization-branding-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Palette, Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import { updateOrganization } from "@/lib/actions/organization";
+
+type Organization = {
+  id: string;
+  name: string;
+  slug: string;
+  branding_config?: {
+    logo_url?: string | null;
+    primary_color?: string | null;
+  } | null;
+};
+
+interface OrganizationBrandingFormProps {
+  organization: Organization;
+  canEdit: boolean;
+}
+
+export function OrganizationBrandingForm({ organization, canEdit }: OrganizationBrandingFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canEdit) return;
+
+    setLoading(true);
+    setMessage(null);
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+
+    // Include organization name and slug to satisfy validation
+    formData.set("name", organization.name);
+    formData.set("slug", organization.slug);
+
+    const result = await updateOrganization(organization.id, formData);
+
+    setLoading(false);
+    if (result.success) {
+      setMessage({ type: "success", text: "Organization branding updated successfully." });
+    } else {
+      setMessage({ type: "error", text: result.error ?? "Failed to update branding." });
+    }
+  }
+
+  const branding = organization.branding_config ?? {};
+
+  return (
+    <Card className="border-border shadow-sm overflow-hidden">
+      <CardHeader className="bg-muted/30 border-b">
+        <CardTitle className="text-lg font-semibold flex items-center gap-2">
+          <Palette className="text-primary w-5 h-5" />
+          Organization Branding
+        </CardTitle>
+        <CardDescription>
+          {canEdit
+            ? "Customize the look and feel of your organization."
+            : "View organization branding. Contact an administrator to make changes."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="org_name_display">Organization Name</Label>
+                <Input
+                  id="org_name_display"
+                  value={organization.name}
+                  className="bg-muted/50"
+                  disabled
+                />
+                <p className="text-xs text-muted-foreground">
+                  Contact support to change your organization name.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="logo_url">Logo URL</Label>
+                <Input
+                  id="logo_url"
+                  name="logo_url"
+                  type="url"
+                  defaultValue={branding.logo_url ?? ""}
+                  placeholder="https://example.com/logo.png"
+                  className="bg-background"
+                  disabled={!canEdit}
+                />
+                {branding.logo_url && (
+                  <div className="mt-2 h-12 flex items-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={branding.logo_url}
+                      alt="Logo preview"
+                      className="max-h-10 max-w-[100px] object-contain"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="primary_color">Primary Color</Label>
+                <div className="flex gap-2 items-center">
+                  <Input
+                    id="primary_color"
+                    name="primary_color"
+                    defaultValue={branding.primary_color ?? ""}
+                    placeholder="#556ee6"
+                    className="bg-background flex-1"
+                    disabled={!canEdit}
+                  />
+                  <div
+                    className="h-10 w-10 shrink-0 rounded-md border border-border"
+                    style={{ backgroundColor: branding.primary_color || "#556ee6" }}
+                    title="Color preview"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Enter a hex color code (e.g., #556ee6)
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {message && (
+            <Alert variant={message.type === "error" ? "destructive" : "default"}>
+              {message.type === "success" ? (
+                <CheckCircle2 className="h-4 w-4" />
+              ) : (
+                <AlertCircle className="h-4 w-4" />
+              )}
+              <AlertDescription>{message.text}</AlertDescription>
+            </Alert>
+          )}
+
+          {canEdit && (
+            <div className="flex justify-end">
+              <Button type="submit" disabled={loading}>
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save Branding"
+                )}
+              </Button>
+            </div>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/actions/organization.ts
+++ b/src/lib/actions/organization.ts
@@ -172,6 +172,7 @@ export async function updateOrganization(
 
     revalidatePath(`/dashboard/clients/${orgId}`);
     revalidatePath("/dashboard/clients");
+    revalidatePath("/dashboard/settings/white-label");
 
     return { success: true };
   } catch (err) {

--- a/supabase/migrations/20260203000005_organizations_update_policy.sql
+++ b/supabase/migrations/20260203000005_organizations_update_policy.sql
@@ -1,0 +1,42 @@
+-- Migration: Add UPDATE policy for organizations table
+-- Description: Allow partners to update their own organization branding and settings
+-- Issue: Partners could not update their organization branding from white-label settings page
+--        because there was no RLS UPDATE policy for the organizations table.
+-- Date: 2026-02-03
+
+-- =============================================================================
+-- ADD UPDATE POLICY FOR ORGANIZATIONS
+-- =============================================================================
+
+-- Allow super admins and staff to update any organization
+DROP POLICY IF EXISTS "Super admins and staff can update organizations" ON organizations;
+CREATE POLICY "Super admins and staff can update organizations"
+  ON organizations FOR UPDATE
+  USING (is_super_admin() OR is_admin_or_staff())
+  WITH CHECK (is_super_admin() OR is_admin_or_staff());
+
+-- Allow partners to update their own organization
+DROP POLICY IF EXISTS "Partners can update own organization" ON organizations;
+CREATE POLICY "Partners can update own organization"
+  ON organizations FOR UPDATE
+  USING (
+    id = get_user_organization_id()
+    AND get_user_role() IN ('partner', 'partner_staff')
+  )
+  WITH CHECK (
+    id = get_user_organization_id()
+    AND get_user_role() IN ('partner', 'partner_staff')
+  );
+
+-- Allow partners to update their client organizations
+DROP POLICY IF EXISTS "Partners can update client organizations" ON organizations;
+CREATE POLICY "Partners can update client organizations"
+  ON organizations FOR UPDATE
+  USING (
+    parent_org_id = get_user_organization_id()
+    AND get_user_role() IN ('partner', 'partner_staff')
+  )
+  WITH CHECK (
+    parent_org_id = get_user_organization_id()
+    AND get_user_role() IN ('partner', 'partner_staff')
+  );


### PR DESCRIPTION
- Add RLS UPDATE policies for organizations table allowing partners to update their own org and child client orgs
- Replace read-only branding display with editable OrganizationBrandingForm
- Add revalidation for white-label settings path on org update

https://claude.ai/code/session_01FnBfU2YonzgWhAhUbSDsYz