### PR TITLE
feat(projects): add project management system

### DIFF
--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -1,0 +1,396 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { redirect, notFound } from 'next/navigation'
+import Link from 'next/link'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  FolderKanban,
+  ChevronLeft,
+  Calendar,
+  Users,
+  Building2,
+  Clock,
+  Target,
+  Settings,
+} from 'lucide-react'
+import { ProjectMembersPanel } from '@/components/projects/project-members-panel'
+import { ProjectOrganizationsPanel } from '@/components/projects/project-organizations-panel'
+import { ProjectSettingsForm } from '@/components/projects/project-settings-form'
+
+function getStatusBadgeVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  switch (status) {
+    case 'active':
+      return 'default'
+    case 'completed':
+      return 'secondary'
+    case 'on_hold':
+    case 'cancelled':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+function getPriorityBadgeClass(priority: string): string {
+  switch (priority) {
+    case 'critical':
+      return 'bg-red-100 text-red-700 border-red-200'
+    case 'high':
+      return 'bg-orange-100 text-orange-700 border-orange-200'
+    case 'medium':
+      return 'bg-blue-100 text-blue-700 border-blue-200'
+    case 'low':
+      return 'bg-slate-100 text-slate-700 border-slate-200'
+    default:
+      return ''
+  }
+}
+
+export default async function ProjectDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id: projectId } = await params
+  const supabase = (await createServerSupabaseClient()) as any
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('id, organization_id, role, is_account_manager')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) redirect('/login')
+
+  const role = profile.role
+  const organizationId = profile.organization_id
+  const isAccountManager = profile.is_account_manager
+
+  // Fetch project with related data
+  const { data: project, error } = await supabase
+    .from('projects')
+    .select(`
+      *,
+      organization:organizations!projects_organization_id_fkey(id, name),
+      creator:users!projects_created_by_fkey(id, email, profiles:profiles(name)),
+      project_members(
+        id,
+        user_id,
+        role,
+        is_active,
+        joined_at,
+        user:users!project_members_user_id_fkey(id, email, role, profiles:profiles(name, avatar_url))
+      ),
+      project_organizations(
+        id,
+        organization_id,
+        role,
+        is_active,
+        organization:organizations!project_organizations_organization_id_fkey(id, name, type, status)
+      )
+    `)
+    .eq('id', projectId)
+    .single()
+
+  if (error || !project) notFound()
+
+  // Determine permissions
+  const isSuperAdmin = role === 'super_admin'
+  const isStaff = role === 'staff'
+  const isPartner = role === 'partner' || role === 'partner_staff'
+
+  const canEdit =
+    isSuperAdmin ||
+    isStaff ||
+    (isPartner && project.organization_id === organizationId) ||
+    (isPartner && isAccountManager)
+
+  // Fetch available staff for assignment
+  let availableStaff: any[] = []
+  let availableOrganizations: any[] = []
+
+  if (canEdit) {
+    const { data: staff } = await supabase
+      .from('users')
+      .select('id, email, role, profiles:profiles(name, avatar_url)')
+      .in('role', ['super_admin', 'staff', 'partner', 'partner_staff'])
+      .eq('status', 'active')
+      .order('email', { ascending: true })
+
+    availableStaff = staff ?? []
+
+    // Fetch organizations for assignment
+    if (isSuperAdmin || isStaff) {
+      const { data: orgs } = await supabase
+        .from('organizations')
+        .select('id, name, type, status')
+        .eq('status', 'active')
+        .order('name', { ascending: true })
+
+      availableOrganizations = orgs ?? []
+    } else if (organizationId) {
+      // Partners can assign their own org and child orgs
+      const { data: orgs } = await supabase
+        .from('organizations')
+        .select('id, name, type, status')
+        .or(`id.eq.${organizationId},parent_org_id.eq.${organizationId}`)
+        .eq('status', 'active')
+        .order('name', { ascending: true })
+
+      availableOrganizations = orgs ?? []
+    }
+  }
+
+  const memberCount = project.project_members?.filter((m: any) => m.is_active).length ?? 0
+  const orgCount = project.project_organizations?.filter((o: any) => o.is_active).length ?? 0
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/dashboard/projects"
+        className="flex items-center gap-2 text-sm text-slate-500 hover:text-primary transition-colors w-fit"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to Projects
+      </Link>
+
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <div className="h-14 w-14 rounded-xl bg-primary/10 flex items-center justify-center">
+            <FolderKanban className="h-7 w-7 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900">
+              {project.name}
+            </h1>
+            <p className="text-slate-500 font-mono text-sm">PRJ-{project.project_number}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={getStatusBadgeVariant(project.status)} className="capitalize">
+            {project.status.replace('_', ' ')}
+          </Badge>
+          <Badge variant="outline" className={`capitalize ${getPriorityBadgeClass(project.priority)}`}>
+            {project.priority}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Quick Stats */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Team Members</CardTitle>
+            <Users className="h-4 w-4 text-slate-400" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{memberCount}</div>
+            <p className="text-xs text-slate-500">Active members</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Organizations</CardTitle>
+            <Building2 className="h-4 w-4 text-slate-400" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{orgCount}</div>
+            <p className="text-xs text-slate-500">Assigned orgs</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Start Date</CardTitle>
+            <Calendar className="h-4 w-4 text-slate-400" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {project.start_date
+                ? new Date(project.start_date).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })
+                : 'Not set'}
+            </div>
+            <p className="text-xs text-slate-500">
+              {project.start_date
+                ? new Date(project.start_date).getFullYear()
+                : 'Schedule pending'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Target End</CardTitle>
+            <Target className="h-4 w-4 text-slate-400" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {project.target_end_date
+                ? new Date(project.target_end_date).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })
+                : 'Not set'}
+            </div>
+            <p className="text-xs text-slate-500">
+              {project.target_end_date
+                ? new Date(project.target_end_date).getFullYear()
+                : 'No deadline'}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Tabbed Content */}
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="overview" className="gap-2">
+            <FolderKanban className="h-4 w-4" />
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="team" className="gap-2">
+            <Users className="h-4 w-4" />
+            Team
+          </TabsTrigger>
+          <TabsTrigger value="organizations" className="gap-2">
+            <Building2 className="h-4 w-4" />
+            Organizations
+          </TabsTrigger>
+          {canEdit && (
+            <TabsTrigger value="settings" className="gap-2">
+              <Settings className="h-4 w-4" />
+              Settings
+            </TabsTrigger>
+          )}
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Project Details</CardTitle>
+              <CardDescription>Overview and description of this project</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {project.description && (
+                <div>
+                  <h4 className="text-sm font-medium text-slate-700 mb-2">Description</h4>
+                  <p className="text-slate-600 whitespace-pre-wrap">{project.description}</p>
+                </div>
+              )}
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-4">
+                  <div className="flex justify-between py-2 border-b border-slate-100">
+                    <span className="text-slate-500">Status</span>
+                    <Badge variant={getStatusBadgeVariant(project.status)} className="capitalize">
+                      {project.status.replace('_', ' ')}
+                    </Badge>
+                  </div>
+                  <div className="flex justify-between py-2 border-b border-slate-100">
+                    <span className="text-slate-500">Priority</span>
+                    <Badge
+                      variant="outline"
+                      className={`capitalize ${getPriorityBadgeClass(project.priority)}`}
+                    >
+                      {project.priority}
+                    </Badge>
+                  </div>
+                  <div className="flex justify-between py-2 border-b border-slate-100">
+                    <span className="text-slate-500">Created By</span>
+                    <span className="font-medium">
+                      {project.creator?.profiles?.name ?? project.creator?.email ?? 'Unknown'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between py-2">
+                    <span className="text-slate-500">Created</span>
+                    <span>{new Date(project.created_at).toLocaleDateString()}</span>
+                  </div>
+                </div>
+                <div className="space-y-4">
+                  <div className="flex justify-between py-2 border-b border-slate-100">
+                    <span className="text-slate-500">Start Date</span>
+                    <span>
+                      {project.start_date
+                        ? new Date(project.start_date).toLocaleDateString()
+                        : 'Not set'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between py-2 border-b border-slate-100">
+                    <span className="text-slate-500">Target End Date</span>
+                    <span>
+                      {project.target_end_date
+                        ? new Date(project.target_end_date).toLocaleDateString()
+                        : 'Not set'}
+                    </span>
+                  </div>
+                  {project.actual_end_date && (
+                    <div className="flex justify-between py-2 border-b border-slate-100">
+                      <span className="text-slate-500">Actual End Date</span>
+                      <span>{new Date(project.actual_end_date).toLocaleDateString()}</span>
+                    </div>
+                  )}
+                  {project.budget_amount && (
+                    <div className="flex justify-between py-2">
+                      <span className="text-slate-500">Budget</span>
+                      <span className="font-medium">
+                        ${(project.budget_amount / 100).toLocaleString()}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {project.tags && project.tags.length > 0 && (
+                <div>
+                  <h4 className="text-sm font-medium text-slate-700 mb-2">Tags</h4>
+                  <div className="flex flex-wrap gap-2">
+                    {project.tags.map((tag: string, index: number) => (
+                      <Badge key={index} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="team">
+          <ProjectMembersPanel
+            projectId={project.id}
+            members={project.project_members ?? []}
+            availableStaff={availableStaff}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+
+        <TabsContent value="organizations">
+          <ProjectOrganizationsPanel
+            projectId={project.id}
+            projectOrganizations={project.project_organizations ?? []}
+            availableOrganizations={availableOrganizations}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+
+        {canEdit && (
+          <TabsContent value="settings">
+            <ProjectSettingsForm project={project} />
+          </TabsContent>
+        )}
+      </Tabs>
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -1,0 +1,262 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { FolderKanban, Clock, CheckCircle2, AlertCircle } from 'lucide-react'
+import { ProjectList } from '@/components/projects/project-list'
+import { CreateProjectDialog } from '@/components/projects/create-project-dialog'
+
+export default async function ProjectsPage() {
+  const supabase = (await createServerSupabaseClient()) as any
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('id, organization_id, role, is_account_manager')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) redirect('/login')
+
+  const organizationId = profile.organization_id
+  const role = profile.role
+  const isAccountManager = profile.is_account_manager
+
+  // Determine if user can create projects
+  const canCreateProject =
+    role === 'super_admin' ||
+    role === 'staff' ||
+    role === 'partner' ||
+    (role === 'partner_staff' && isAccountManager)
+
+  // Fetch projects based on role
+  let projects: any[] = []
+  let stats = { total: 0, active: 0, completed: 0, onHold: 0 }
+
+  if (role === 'super_admin' || role === 'staff') {
+    // Staff/admin can see all projects
+    const { data } = await supabase
+      .from('projects')
+      .select(`
+        id,
+        project_number,
+        name,
+        description,
+        status,
+        priority,
+        start_date,
+        target_end_date,
+        created_at,
+        created_by,
+        organization:organizations!projects_organization_id_fkey(id, name),
+        project_members(
+          id,
+          user_id,
+          role,
+          user:users!project_members_user_id_fkey(id, email, profiles:profiles(name, avatar_url))
+        ),
+        project_organizations(
+          id,
+          organization_id,
+          role,
+          organization:organizations!project_organizations_organization_id_fkey(id, name)
+        )
+      `)
+      .order('created_at', { ascending: false })
+
+    projects = data ?? []
+  } else if (role === 'partner' || role === 'partner_staff') {
+    // Partners see their org's projects and projects with their clients assigned
+    const { data } = await supabase
+      .from('projects')
+      .select(`
+        id,
+        project_number,
+        name,
+        description,
+        status,
+        priority,
+        start_date,
+        target_end_date,
+        created_at,
+        created_by,
+        organization:organizations!projects_organization_id_fkey(id, name),
+        project_members(
+          id,
+          user_id,
+          role,
+          user:users!project_members_user_id_fkey(id, email, profiles:profiles(name, avatar_url))
+        ),
+        project_organizations(
+          id,
+          organization_id,
+          role,
+          organization:organizations!project_organizations_organization_id_fkey(id, name)
+        )
+      `)
+      .order('created_at', { ascending: false })
+
+    projects = data ?? []
+  } else {
+    // Clients see only projects where their org is assigned
+    const { data } = await supabase
+      .from('projects')
+      .select(`
+        id,
+        project_number,
+        name,
+        description,
+        status,
+        priority,
+        start_date,
+        target_end_date,
+        created_at,
+        created_by,
+        organization:organizations!projects_organization_id_fkey(id, name),
+        project_members(
+          id,
+          user_id,
+          role,
+          user:users!project_members_user_id_fkey(id, email, profiles:profiles(name, avatar_url))
+        ),
+        project_organizations(
+          id,
+          organization_id,
+          role,
+          organization:organizations!project_organizations_organization_id_fkey(id, name)
+        )
+      `)
+      .order('created_at', { ascending: false })
+
+    projects = data ?? []
+  }
+
+  // Calculate stats
+  stats.total = projects.length
+  stats.active = projects.filter((p) => p.status === 'active').length
+  stats.completed = projects.filter((p) => p.status === 'completed').length
+  stats.onHold = projects.filter((p) => p.status === 'on_hold').length
+
+  // Fetch staff users for assignment (if user can create projects)
+  let staffUsers: any[] = []
+  let clientOrganizations: any[] = []
+
+  if (canCreateProject) {
+    const { data: staff } = await supabase
+      .from('users')
+      .select('id, email, role, profiles:profiles(name, avatar_url)')
+      .in('role', ['super_admin', 'staff', 'partner', 'partner_staff'])
+      .eq('status', 'active')
+      .order('email', { ascending: true })
+
+    staffUsers = staff ?? []
+
+    // Fetch organizations for assignment
+    if (role === 'super_admin' || role === 'staff') {
+      const { data: orgs } = await supabase
+        .from('organizations')
+        .select('id, name, type, status')
+        .eq('status', 'active')
+        .order('name', { ascending: true })
+
+      clientOrganizations = orgs ?? []
+    } else if (organizationId) {
+      // Partners can assign their own org and child orgs
+      const { data: orgs } = await supabase
+        .from('organizations')
+        .select('id, name, type, status')
+        .or(`id.eq.${organizationId},parent_org_id.eq.${organizationId}`)
+        .eq('status', 'active')
+        .order('name', { ascending: true })
+
+      clientOrganizations = orgs ?? []
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight text-slate-900">
+            Projects
+          </h2>
+          <p className="text-slate-500">
+            Manage and track your projects and service requests.
+          </p>
+        </div>
+        {canCreateProject && (
+          <CreateProjectDialog
+            staffUsers={staffUsers}
+            organizations={clientOrganizations}
+            userOrganizationId={organizationId}
+          />
+        )}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <StatsCard
+          title="Total Projects"
+          value={String(stats.total)}
+          icon={<FolderKanban className="text-slate-400" size={20} />}
+        />
+        <StatsCard
+          title="Active"
+          value={String(stats.active)}
+          icon={<Clock className="text-blue-400" size={20} />}
+        />
+        <StatsCard
+          title="Completed"
+          value={String(stats.completed)}
+          icon={<CheckCircle2 className="text-green-400" size={20} />}
+        />
+        <StatsCard
+          title="On Hold"
+          value={String(stats.onHold)}
+          icon={<AlertCircle className="text-amber-400" size={20} />}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All Projects</CardTitle>
+          <CardDescription>
+            {canCreateProject
+              ? 'View and manage all projects in your organization.'
+              : 'View projects assigned to your organization.'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ProjectList projects={projects} canEdit={canCreateProject} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function StatsCard({
+  title,
+  value,
+  icon,
+}: {
+  title: string
+  value: string
+  icon?: React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   UserCog,
   Plug,
   Layers,
+  FolderKanban,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -88,6 +89,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     label: "Admin",
     items: [
       { href: "/dashboard/clients", icon: Users, label: "Clients" },
+      { href: "/dashboard/projects", icon: FolderKanban, label: "Projects" },
       { href: "/dashboard/users", icon: UserCog, label: "User Management" },
       { href: "/dashboard/tenants", icon: Building2, label: "Tenants" },
       { href: "/dashboard/plans", icon: Layers, label: "Plans" },
@@ -144,6 +146,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         whiteLabel,
         "/dashboard/integrations",
         "/dashboard/clients",
+        "/dashboard/projects",
         ...adminStaff,
         "/dashboard/admin/services",
         "/dashboard/admin/contracts",
@@ -158,6 +161,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         ...supportClient,
         "/dashboard/capacity",
         ...(isAccountManager ? accountBase : accountBaseNoInvoices),
+        "/dashboard/projects",
         ...adminStaff,
         "/dashboard/admin/services",
         "/dashboard/admin/contracts",
@@ -170,6 +174,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         ...accountBase,
         whiteLabel,
         "/dashboard/clients",
+        "/dashboard/projects",
         "/dashboard/plans",
         "/dashboard/reports",
       ];
@@ -177,6 +182,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
       return [
         "/dashboard",
         ...supportClient,
+        "/dashboard/projects",
         "/dashboard/invoices",
         "/dashboard/settings",
         "/dashboard/profile",
@@ -187,6 +193,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
       return [
         "/dashboard",
         ...supportClient,
+        "/dashboard/projects",
         ...accountBase,
       ];
     default:

--- a/src/components/projects/create-project-dialog.tsx
+++ b/src/components/projects/create-project-dialog.tsx
@@ -1,0 +1,507 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Plus, Loader2 } from 'lucide-react'
+import {
+  createProjectSchema,
+  CreateProjectInput,
+  PROJECT_STATUS_OPTIONS,
+  PROJECT_PRIORITY_OPTIONS,
+  PROJECT_MEMBER_ROLE_OPTIONS,
+  PROJECT_ORG_ROLE_OPTIONS,
+} from '@/lib/validators/project'
+
+type StaffUser = {
+  id: string
+  email: string
+  role: string
+  profiles: { name: string | null; avatar_url: string | null } | null
+}
+
+type Organization = {
+  id: string
+  name: string
+  type: string
+  status: string
+}
+
+interface CreateProjectDialogProps {
+  staffUsers: StaffUser[]
+  organizations: Organization[]
+  userOrganizationId: string | null
+}
+
+type MemberSelection = {
+  userId: string
+  role: string
+}
+
+type OrgSelection = {
+  organizationId: string
+  role: string
+}
+
+export function CreateProjectDialog({
+  staffUsers,
+  organizations,
+  userOrganizationId,
+}: CreateProjectDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [selectedMembers, setSelectedMembers] = useState<MemberSelection[]>([])
+  const [selectedOrgs, setSelectedOrgs] = useState<OrgSelection[]>([])
+  const router = useRouter()
+  const supabase = createClient()
+
+  const form = useForm<CreateProjectInput>({
+    resolver: zodResolver(createProjectSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      status: 'planning',
+      priority: 'medium',
+      start_date: null,
+      target_end_date: null,
+      tags: [],
+    },
+  })
+
+  const toggleMember = (userId: string) => {
+    setSelectedMembers((prev) => {
+      const existing = prev.find((m) => m.userId === userId)
+      if (existing) {
+        return prev.filter((m) => m.userId !== userId)
+      }
+      return [...prev, { userId, role: 'team_member' }]
+    })
+  }
+
+  const updateMemberRole = (userId: string, role: string) => {
+    setSelectedMembers((prev) =>
+      prev.map((m) => (m.userId === userId ? { ...m, role } : m))
+    )
+  }
+
+  const toggleOrg = (organizationId: string) => {
+    setSelectedOrgs((prev) => {
+      const existing = prev.find((o) => o.organizationId === organizationId)
+      if (existing) {
+        return prev.filter((o) => o.organizationId !== organizationId)
+      }
+      return [...prev, { organizationId, role: 'client' }]
+    })
+  }
+
+  const updateOrgRole = (organizationId: string, role: string) => {
+    setSelectedOrgs((prev) =>
+      prev.map((o) => (o.organizationId === organizationId ? { ...o, role } : o))
+    )
+  }
+
+  async function onSubmit(values: CreateProjectInput) {
+    setIsSubmitting(true)
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (!user) {
+        throw new Error('Not authenticated')
+      }
+
+      // Create the project
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .insert({
+          name: values.name,
+          description: values.description || null,
+          status: values.status,
+          priority: values.priority,
+          start_date: values.start_date || null,
+          target_end_date: values.target_end_date || null,
+          tags: values.tags || [],
+          organization_id: userOrganizationId,
+          created_by: user.id,
+        })
+        .select('id')
+        .single()
+
+      if (projectError) throw projectError
+
+      // Add team members
+      if (selectedMembers.length > 0) {
+        const memberInserts = selectedMembers.map((m) => ({
+          project_id: project.id,
+          user_id: m.userId,
+          role: m.role,
+          assigned_by: user.id,
+        }))
+
+        const { error: membersError } = await supabase
+          .from('project_members')
+          .insert(memberInserts)
+
+        if (membersError) {
+          console.error('Error adding members:', membersError)
+        }
+      }
+
+      // Add organizations
+      if (selectedOrgs.length > 0) {
+        const orgInserts = selectedOrgs.map((o) => ({
+          project_id: project.id,
+          organization_id: o.organizationId,
+          role: o.role,
+          assigned_by: user.id,
+        }))
+
+        const { error: orgsError } = await supabase
+          .from('project_organizations')
+          .insert(orgInserts)
+
+        if (orgsError) {
+          console.error('Error adding organizations:', orgsError)
+        }
+      }
+
+      setOpen(false)
+      form.reset()
+      setSelectedMembers([])
+      setSelectedOrgs([])
+      router.refresh()
+      router.push(`/dashboard/projects/${project.id}`)
+    } catch (error) {
+      console.error('Failed to create project:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="gap-2">
+          <Plus size={18} />
+          New Project
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Create New Project</DialogTitle>
+          <DialogDescription>
+            Set up a new project and assign team members and organizations.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 overflow-hidden">
+            <ScrollArea className="flex-1 pr-4">
+              <div className="space-y-6 pb-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Project Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Enter project name" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Describe the project objectives and scope..."
+                          className="min-h-[100px]"
+                          {...field}
+                          value={field.value ?? ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="status"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Status</FormLabel>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select status" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {PROJECT_STATUS_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="priority"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Priority</FormLabel>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select priority" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {PROJECT_PRIORITY_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="start_date"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Start Date</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="date"
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="target_end_date"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Target End Date</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="date"
+                            {...field}
+                            value={field.value ?? ''}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {/* Team Members Section */}
+                <div className="space-y-3">
+                  <Label>Team Members</Label>
+                  <FormDescription>
+                    Select team members to assign to this project.
+                  </FormDescription>
+                  <div className="border rounded-lg max-h-[200px] overflow-y-auto">
+                    {staffUsers.length === 0 ? (
+                      <p className="p-4 text-sm text-slate-500">No staff users available.</p>
+                    ) : (
+                      <div className="divide-y">
+                        {staffUsers.map((user) => {
+                          const isSelected = selectedMembers.some((m) => m.userId === user.id)
+                          const selection = selectedMembers.find((m) => m.userId === user.id)
+                          const displayName = user.profiles?.name ?? user.email
+
+                          return (
+                            <div
+                              key={user.id}
+                              className="flex items-center justify-between p-3 hover:bg-slate-50"
+                            >
+                              <div className="flex items-center gap-3">
+                                <Checkbox
+                                  id={`member-${user.id}`}
+                                  checked={isSelected}
+                                  onCheckedChange={() => toggleMember(user.id)}
+                                />
+                                <Label
+                                  htmlFor={`member-${user.id}`}
+                                  className="cursor-pointer font-normal"
+                                >
+                                  <span className="block">{displayName}</span>
+                                  <span className="text-xs text-slate-500">{user.email}</span>
+                                </Label>
+                              </div>
+                              {isSelected && (
+                                <Select
+                                  value={selection?.role ?? 'team_member'}
+                                  onValueChange={(value) => updateMemberRole(user.id, value)}
+                                >
+                                  <SelectTrigger className="w-[150px] h-8">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {PROJECT_MEMBER_ROLE_OPTIONS.map((option) => (
+                                      <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Organizations Section */}
+                <div className="space-y-3">
+                  <Label>Organizations</Label>
+                  <FormDescription>
+                    Assign client organizations to this project.
+                  </FormDescription>
+                  <div className="border rounded-lg max-h-[200px] overflow-y-auto">
+                    {organizations.length === 0 ? (
+                      <p className="p-4 text-sm text-slate-500">No organizations available.</p>
+                    ) : (
+                      <div className="divide-y">
+                        {organizations.map((org) => {
+                          const isSelected = selectedOrgs.some(
+                            (o) => o.organizationId === org.id
+                          )
+                          const selection = selectedOrgs.find(
+                            (o) => o.organizationId === org.id
+                          )
+
+                          return (
+                            <div
+                              key={org.id}
+                              className="flex items-center justify-between p-3 hover:bg-slate-50"
+                            >
+                              <div className="flex items-center gap-3">
+                                <Checkbox
+                                  id={`org-${org.id}`}
+                                  checked={isSelected}
+                                  onCheckedChange={() => toggleOrg(org.id)}
+                                />
+                                <Label
+                                  htmlFor={`org-${org.id}`}
+                                  className="cursor-pointer font-normal"
+                                >
+                                  <span className="block">{org.name}</span>
+                                  <span className="text-xs text-slate-500 capitalize">
+                                    {org.type}
+                                  </span>
+                                </Label>
+                              </div>
+                              {isSelected && (
+                                <Select
+                                  value={selection?.role ?? 'client'}
+                                  onValueChange={(value) => updateOrgRole(org.id, value)}
+                                >
+                                  <SelectTrigger className="w-[150px] h-8">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {PROJECT_ORG_ROLE_OPTIONS.map((option) => (
+                                      <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              )}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </ScrollArea>
+
+            <DialogFooter className="mt-4 pt-4 border-t">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Project
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-list.tsx
+++ b/src/components/projects/project-list.tsx
@@ -1,0 +1,314 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { FolderKanban, Search, Users, Building2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PROJECT_STATUS_OPTIONS, PROJECT_PRIORITY_OPTIONS } from '@/lib/validators/project'
+
+type ProjectMember = {
+  id: string
+  user_id: string
+  role: string
+  user: {
+    id: string
+    email: string
+    profiles: { name: string | null; avatar_url: string | null } | null
+  } | null
+}
+
+type ProjectOrganization = {
+  id: string
+  organization_id: string
+  role: string
+  organization: {
+    id: string
+    name: string
+  } | null
+}
+
+type Project = {
+  id: string
+  project_number: number
+  name: string
+  description: string | null
+  status: string
+  priority: string
+  start_date: string | null
+  target_end_date: string | null
+  created_at: string
+  created_by: string
+  organization: { id: string; name: string } | null
+  project_members: ProjectMember[]
+  project_organizations: ProjectOrganization[]
+}
+
+interface ProjectListProps {
+  projects: Project[]
+  canEdit: boolean
+}
+
+function getStatusBadgeVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  switch (status) {
+    case 'active':
+      return 'default'
+    case 'completed':
+      return 'secondary'
+    case 'on_hold':
+    case 'cancelled':
+      return 'destructive'
+    default:
+      return 'outline'
+  }
+}
+
+function getPriorityBadgeClass(priority: string): string {
+  switch (priority) {
+    case 'critical':
+      return 'bg-red-100 text-red-700 border-red-200'
+    case 'high':
+      return 'bg-orange-100 text-orange-700 border-orange-200'
+    case 'medium':
+      return 'bg-blue-100 text-blue-700 border-blue-200'
+    case 'low':
+      return 'bg-slate-100 text-slate-700 border-slate-200'
+    default:
+      return ''
+  }
+}
+
+export function ProjectList({ projects, canEdit }: ProjectListProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [priorityFilter, setPriorityFilter] = useState<string>('all')
+
+  const filteredProjects = projects.filter((project) => {
+    const matchesSearch =
+      project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      project.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      `PRJ-${project.project_number}`.toLowerCase().includes(searchQuery.toLowerCase())
+
+    const matchesStatus = statusFilter === 'all' || project.status === statusFilter
+    const matchesPriority = priorityFilter === 'all' || project.priority === priorityFilter
+
+    return matchesSearch && matchesStatus && matchesPriority
+  })
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <FolderKanban className="h-12 w-12 text-slate-300 mb-4" />
+        <h3 className="text-lg font-medium text-slate-900 mb-1">No projects yet</h3>
+        <p className="text-slate-500 text-sm max-w-sm">
+          {canEdit
+            ? 'Create your first project to get started.'
+            : 'No projects have been assigned to your organization yet.'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="Search projects..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-full sm:w-[150px]">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Statuses</SelectItem>
+            {PROJECT_STATUS_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={priorityFilter} onValueChange={setPriorityFilter}>
+          <SelectTrigger className="w-full sm:w-[150px]">
+            <SelectValue placeholder="Priority" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Priorities</SelectItem>
+            {PROJECT_PRIORITY_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {filteredProjects.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center border rounded-lg">
+          <Search className="h-8 w-8 text-slate-300 mb-4" />
+          <h3 className="text-lg font-medium text-slate-900 mb-1">No matching projects</h3>
+          <p className="text-slate-500 text-sm">Try adjusting your search or filters.</p>
+        </div>
+      ) : (
+        <div className="border rounded-lg overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Project</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Priority</TableHead>
+                <TableHead>Team</TableHead>
+                <TableHead>Organizations</TableHead>
+                <TableHead>Dates</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredProjects.map((project) => {
+                const projectManagers = project.project_members.filter(
+                  (m) => m.role === 'project_manager' || m.role === 'account_manager'
+                )
+                const clientOrgs = project.project_organizations.filter((o) => o.role === 'client')
+
+                return (
+                  <TableRow key={project.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                          <FolderKanban className="h-5 w-5 text-primary" />
+                        </div>
+                        <div className="min-w-0">
+                          <Link
+                            href={`/dashboard/projects/${project.id}`}
+                            className="font-medium text-slate-900 hover:text-primary transition-colors block truncate"
+                          >
+                            {project.name}
+                          </Link>
+                          <p className="text-xs text-slate-500 font-mono">
+                            PRJ-{project.project_number}
+                          </p>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getStatusBadgeVariant(project.status)} className="capitalize">
+                        {project.status.replace('_', ' ')}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={cn('capitalize', getPriorityBadgeClass(project.priority))}
+                      >
+                        {project.priority}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {projectManagers.length > 0 ? (
+                        <div className="flex -space-x-2">
+                          {projectManagers.slice(0, 3).map((member) => {
+                            const name = member.user?.profiles?.name ?? member.user?.email ?? '?'
+                            const initials = name
+                              .split(' ')
+                              .map((n) => n[0])
+                              .join('')
+                              .toUpperCase()
+                              .slice(0, 2)
+                            return (
+                              <Avatar
+                                key={member.id}
+                                className="h-8 w-8 border-2 border-white"
+                                title={name}
+                              >
+                                <AvatarImage src={member.user?.profiles?.avatar_url ?? undefined} />
+                                <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+                              </Avatar>
+                            )
+                          })}
+                          {projectManagers.length > 3 && (
+                            <div className="h-8 w-8 rounded-full bg-slate-100 border-2 border-white flex items-center justify-center text-xs text-slate-600">
+                              +{projectManagers.length - 3}
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-slate-400 text-sm">
+                          <Users className="h-4 w-4" />
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {clientOrgs.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                          {clientOrgs.slice(0, 2).map((org) => (
+                            <Badge key={org.id} variant="outline" className="text-xs">
+                              <Building2 className="h-3 w-3 mr-1" />
+                              {org.organization?.name}
+                            </Badge>
+                          ))}
+                          {clientOrgs.length > 2 && (
+                            <Badge variant="outline" className="text-xs">
+                              +{clientOrgs.length - 2}
+                            </Badge>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="text-slate-400 text-sm">
+                          <Building2 className="h-4 w-4" />
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">
+                        {project.start_date ? (
+                          <span>{new Date(project.start_date).toLocaleDateString()}</span>
+                        ) : (
+                          <span className="text-slate-400">Not set</span>
+                        )}
+                        {project.target_end_date && (
+                          <>
+                            <span className="text-slate-400 mx-1">-</span>
+                            <span>{new Date(project.target_end_date).toLocaleDateString()}</span>
+                          </>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="ghost" size="sm" asChild>
+                        <Link href={`/dashboard/projects/${project.id}`}>View</Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/projects/project-members-panel.tsx
+++ b/src/components/projects/project-members-panel.tsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { UserPlus, Loader2, Trash2, Users } from 'lucide-react'
+import { PROJECT_MEMBER_ROLE_OPTIONS } from '@/lib/validators/project'
+
+type ProjectMember = {
+  id: string
+  user_id: string
+  role: string
+  is_active: boolean
+  joined_at: string
+  user: {
+    id: string
+    email: string
+    role: string
+    profiles: { name: string | null; avatar_url: string | null } | null
+  } | null
+}
+
+type StaffUser = {
+  id: string
+  email: string
+  role: string
+  profiles: { name: string | null; avatar_url: string | null } | null
+}
+
+interface ProjectMembersPanelProps {
+  projectId: string
+  members: ProjectMember[]
+  availableStaff: StaffUser[]
+  canEdit: boolean
+}
+
+function getRoleBadgeColor(role: string): string {
+  switch (role) {
+    case 'project_manager':
+      return 'bg-purple-100 text-purple-700 border-purple-200'
+    case 'account_manager':
+      return 'bg-blue-100 text-blue-700 border-blue-200'
+    case 'team_member':
+      return 'bg-green-100 text-green-700 border-green-200'
+    case 'observer':
+      return 'bg-slate-100 text-slate-700 border-slate-200'
+    default:
+      return ''
+  }
+}
+
+export function ProjectMembersPanel({
+  projectId,
+  members,
+  availableStaff,
+  canEdit,
+}: ProjectMembersPanelProps) {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [selectedUsers, setSelectedUsers] = useState<{ userId: string; role: string }[]>([])
+  const [updatingMemberId, setUpdatingMemberId] = useState<string | null>(null)
+  const router = useRouter()
+  const supabase = createClient()
+
+  const activeMembers = members.filter((m) => m.is_active)
+  const existingMemberIds = members.map((m) => m.user_id)
+  const availableToAdd = availableStaff.filter((s) => !existingMemberIds.includes(s.id))
+
+  const toggleUser = (userId: string) => {
+    setSelectedUsers((prev) => {
+      const existing = prev.find((u) => u.userId === userId)
+      if (existing) {
+        return prev.filter((u) => u.userId !== userId)
+      }
+      return [...prev, { userId, role: 'team_member' }]
+    })
+  }
+
+  const updateSelectedRole = (userId: string, role: string) => {
+    setSelectedUsers((prev) =>
+      prev.map((u) => (u.userId === userId ? { ...u, role } : u))
+    )
+  }
+
+  async function handleAddMembers() {
+    if (selectedUsers.length === 0) return
+
+    setIsSubmitting(true)
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      const inserts = selectedUsers.map((s) => ({
+        project_id: projectId,
+        user_id: s.userId,
+        role: s.role,
+        assigned_by: user?.id,
+      }))
+
+      const { error } = await supabase.from('project_members').insert(inserts)
+
+      if (error) throw error
+
+      setIsAddDialogOpen(false)
+      setSelectedUsers([])
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to add members:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleUpdateRole(memberId: string, newRole: string) {
+    setUpdatingMemberId(memberId)
+    try {
+      const { error } = await supabase
+        .from('project_members')
+        .update({ role: newRole })
+        .eq('id', memberId)
+
+      if (error) throw error
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to update role:', error)
+    } finally {
+      setUpdatingMemberId(null)
+    }
+  }
+
+  async function handleRemoveMember(memberId: string) {
+    if (!confirm('Are you sure you want to remove this member from the project?')) return
+
+    setUpdatingMemberId(memberId)
+    try {
+      const { error } = await supabase
+        .from('project_members')
+        .update({ is_active: false, left_at: new Date().toISOString() })
+        .eq('id', memberId)
+
+      if (error) throw error
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to remove member:', error)
+    } finally {
+      setUpdatingMemberId(null)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Team Members</CardTitle>
+            <CardDescription>
+              People assigned to work on this project
+            </CardDescription>
+          </div>
+          {canEdit && (
+            <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" className="gap-2">
+                  <UserPlus className="h-4 w-4" />
+                  Add Member
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Add Team Members</DialogTitle>
+                  <DialogDescription>
+                    Select staff members to add to this project.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <ScrollArea className="max-h-[400px] pr-4">
+                  {availableToAdd.length === 0 ? (
+                    <p className="py-8 text-center text-slate-500">
+                      All available staff members are already assigned.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {availableToAdd.map((user) => {
+                        const isSelected = selectedUsers.some((s) => s.userId === user.id)
+                        const selection = selectedUsers.find((s) => s.userId === user.id)
+                        const displayName = user.profiles?.name ?? user.email
+
+                        return (
+                          <div
+                            key={user.id}
+                            className="flex items-center justify-between p-3 rounded-lg border hover:bg-slate-50"
+                          >
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id={`add-member-${user.id}`}
+                                checked={isSelected}
+                                onCheckedChange={() => toggleUser(user.id)}
+                              />
+                              <Avatar className="h-8 w-8">
+                                <AvatarImage src={user.profiles?.avatar_url ?? undefined} />
+                                <AvatarFallback className="text-xs">
+                                  {displayName.slice(0, 2).toUpperCase()}
+                                </AvatarFallback>
+                              </Avatar>
+                              <Label
+                                htmlFor={`add-member-${user.id}`}
+                                className="cursor-pointer font-normal"
+                              >
+                                <span className="block">{displayName}</span>
+                                <span className="text-xs text-slate-500">{user.email}</span>
+                              </Label>
+                            </div>
+                            {isSelected && (
+                              <Select
+                                value={selection?.role ?? 'team_member'}
+                                onValueChange={(value) => updateSelectedRole(user.id, value)}
+                              >
+                                <SelectTrigger className="w-[130px] h-8">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {PROJECT_MEMBER_ROLE_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </ScrollArea>
+
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setIsAddDialogOpen(false)
+                      setSelectedUsers([])
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleAddMembers}
+                    disabled={selectedUsers.length === 0 || isSubmitting}
+                  >
+                    {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Add {selectedUsers.length > 0 ? `(${selectedUsers.length})` : ''}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {activeMembers.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center border rounded-lg border-dashed">
+            <Users className="h-10 w-10 text-slate-300 mb-4" />
+            <h3 className="text-lg font-medium text-slate-900 mb-1">No team members</h3>
+            <p className="text-slate-500 text-sm">
+              {canEdit
+                ? 'Add team members to start collaborating on this project.'
+                : 'No team members have been assigned yet.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {activeMembers.map((member) => {
+              const displayName = member.user?.profiles?.name ?? member.user?.email ?? 'Unknown'
+              const initials = displayName.slice(0, 2).toUpperCase()
+              const isUpdating = updatingMemberId === member.id
+
+              return (
+                <div
+                  key={member.id}
+                  className="flex items-center justify-between p-4 rounded-lg border bg-slate-50/50"
+                >
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage src={member.user?.profiles?.avatar_url ?? undefined} />
+                      <AvatarFallback>{initials}</AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="font-medium text-slate-900">{displayName}</p>
+                      <p className="text-sm text-slate-500">{member.user?.email}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {canEdit ? (
+                      <>
+                        <Select
+                          value={member.role}
+                          onValueChange={(value) => handleUpdateRole(member.id, value)}
+                          disabled={isUpdating}
+                        >
+                          <SelectTrigger className="w-[150px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {PROJECT_MEMBER_ROLE_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemoveMember(member.id)}
+                          disabled={isUpdating}
+                          className="text-slate-400 hover:text-red-500"
+                        >
+                          {isUpdating ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </>
+                    ) : (
+                      <Badge variant="outline" className={getRoleBadgeColor(member.role)}>
+                        {PROJECT_MEMBER_ROLE_OPTIONS.find((r) => r.value === member.role)?.label ??
+                          member.role}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/projects/project-organizations-panel.tsx
+++ b/src/components/projects/project-organizations-panel.tsx
@@ -1,0 +1,361 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Building2, Plus, Loader2, Trash2 } from 'lucide-react'
+import { PROJECT_ORG_ROLE_OPTIONS } from '@/lib/validators/project'
+
+type ProjectOrganization = {
+  id: string
+  organization_id: string
+  role: string
+  is_active: boolean
+  organization: {
+    id: string
+    name: string
+    type: string
+    status: string
+  } | null
+}
+
+type Organization = {
+  id: string
+  name: string
+  type: string
+  status: string
+}
+
+interface ProjectOrganizationsPanelProps {
+  projectId: string
+  projectOrganizations: ProjectOrganization[]
+  availableOrganizations: Organization[]
+  canEdit: boolean
+}
+
+function getRoleBadgeColor(role: string): string {
+  switch (role) {
+    case 'client':
+      return 'bg-blue-100 text-blue-700 border-blue-200'
+    case 'partner':
+      return 'bg-purple-100 text-purple-700 border-purple-200'
+    case 'vendor':
+      return 'bg-orange-100 text-orange-700 border-orange-200'
+    case 'collaborator':
+      return 'bg-green-100 text-green-700 border-green-200'
+    default:
+      return ''
+  }
+}
+
+export function ProjectOrganizationsPanel({
+  projectId,
+  projectOrganizations,
+  availableOrganizations,
+  canEdit,
+}: ProjectOrganizationsPanelProps) {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [selectedOrgs, setSelectedOrgs] = useState<{ orgId: string; role: string }[]>([])
+  const [updatingOrgId, setUpdatingOrgId] = useState<string | null>(null)
+  const router = useRouter()
+  const supabase = createClient()
+
+  const activeOrgs = projectOrganizations.filter((o) => o.is_active)
+  const existingOrgIds = projectOrganizations.map((o) => o.organization_id)
+  const availableToAdd = availableOrganizations.filter((o) => !existingOrgIds.includes(o.id))
+
+  const toggleOrg = (orgId: string) => {
+    setSelectedOrgs((prev) => {
+      const existing = prev.find((o) => o.orgId === orgId)
+      if (existing) {
+        return prev.filter((o) => o.orgId !== orgId)
+      }
+      return [...prev, { orgId, role: 'client' }]
+    })
+  }
+
+  const updateSelectedRole = (orgId: string, role: string) => {
+    setSelectedOrgs((prev) => prev.map((o) => (o.orgId === orgId ? { ...o, role } : o)))
+  }
+
+  async function handleAddOrganizations() {
+    if (selectedOrgs.length === 0) return
+
+    setIsSubmitting(true)
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      const inserts = selectedOrgs.map((o) => ({
+        project_id: projectId,
+        organization_id: o.orgId,
+        role: o.role,
+        assigned_by: user?.id,
+      }))
+
+      const { error } = await supabase.from('project_organizations').insert(inserts)
+
+      if (error) throw error
+
+      setIsAddDialogOpen(false)
+      setSelectedOrgs([])
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to add organizations:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleUpdateRole(projectOrgId: string, newRole: string) {
+    setUpdatingOrgId(projectOrgId)
+    try {
+      const { error } = await supabase
+        .from('project_organizations')
+        .update({ role: newRole })
+        .eq('id', projectOrgId)
+
+      if (error) throw error
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to update role:', error)
+    } finally {
+      setUpdatingOrgId(null)
+    }
+  }
+
+  async function handleRemoveOrganization(projectOrgId: string) {
+    if (!confirm('Are you sure you want to remove this organization from the project?')) return
+
+    setUpdatingOrgId(projectOrgId)
+    try {
+      const { error } = await supabase
+        .from('project_organizations')
+        .update({ is_active: false })
+        .eq('id', projectOrgId)
+
+      if (error) throw error
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to remove organization:', error)
+    } finally {
+      setUpdatingOrgId(null)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Organizations</CardTitle>
+            <CardDescription>
+              Client organizations and partners associated with this project
+            </CardDescription>
+          </div>
+          {canEdit && (
+            <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add Organization
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Add Organizations</DialogTitle>
+                  <DialogDescription>
+                    Select organizations to associate with this project.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <ScrollArea className="max-h-[400px] pr-4">
+                  {availableToAdd.length === 0 ? (
+                    <p className="py-8 text-center text-slate-500">
+                      All available organizations are already assigned.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {availableToAdd.map((org) => {
+                        const isSelected = selectedOrgs.some((o) => o.orgId === org.id)
+                        const selection = selectedOrgs.find((o) => o.orgId === org.id)
+
+                        return (
+                          <div
+                            key={org.id}
+                            className="flex items-center justify-between p-3 rounded-lg border hover:bg-slate-50"
+                          >
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id={`add-org-${org.id}`}
+                                checked={isSelected}
+                                onCheckedChange={() => toggleOrg(org.id)}
+                              />
+                              <div className="h-8 w-8 rounded-lg bg-slate-100 flex items-center justify-center">
+                                <Building2 className="h-4 w-4 text-slate-500" />
+                              </div>
+                              <Label
+                                htmlFor={`add-org-${org.id}`}
+                                className="cursor-pointer font-normal"
+                              >
+                                <span className="block">{org.name}</span>
+                                <span className="text-xs text-slate-500 capitalize">{org.type}</span>
+                              </Label>
+                            </div>
+                            {isSelected && (
+                              <Select
+                                value={selection?.role ?? 'client'}
+                                onValueChange={(value) => updateSelectedRole(org.id, value)}
+                              >
+                                <SelectTrigger className="w-[130px] h-8">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {PROJECT_ORG_ROLE_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </ScrollArea>
+
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setIsAddDialogOpen(false)
+                      setSelectedOrgs([])
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleAddOrganizations}
+                    disabled={selectedOrgs.length === 0 || isSubmitting}
+                  >
+                    {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    Add {selectedOrgs.length > 0 ? `(${selectedOrgs.length})` : ''}
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {activeOrgs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-center border rounded-lg border-dashed">
+            <Building2 className="h-10 w-10 text-slate-300 mb-4" />
+            <h3 className="text-lg font-medium text-slate-900 mb-1">No organizations</h3>
+            <p className="text-slate-500 text-sm">
+              {canEdit
+                ? 'Add client organizations to associate with this project.'
+                : 'No organizations have been assigned yet.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {activeOrgs.map((projectOrg) => {
+              const org = projectOrg.organization
+              const isUpdating = updatingOrgId === projectOrg.id
+
+              return (
+                <div
+                  key={projectOrg.id}
+                  className="flex items-center justify-between p-4 rounded-lg border bg-slate-50/50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Building2 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div>
+                      <p className="font-medium text-slate-900">{org?.name ?? 'Unknown'}</p>
+                      <p className="text-sm text-slate-500 capitalize">{org?.type ?? 'Unknown'}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {canEdit ? (
+                      <>
+                        <Select
+                          value={projectOrg.role}
+                          onValueChange={(value) => handleUpdateRole(projectOrg.id, value)}
+                          disabled={isUpdating}
+                        >
+                          <SelectTrigger className="w-[130px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {PROJECT_ORG_ROLE_OPTIONS.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemoveOrganization(projectOrg.id)}
+                          disabled={isUpdating}
+                          className="text-slate-400 hover:text-red-500"
+                        >
+                          {isUpdating ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </>
+                    ) : (
+                      <Badge variant="outline" className={getRoleBadgeColor(projectOrg.role)}>
+                        {PROJECT_ORG_ROLE_OPTIONS.find((r) => r.value === projectOrg.role)?.label ??
+                          projectOrg.role}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/projects/project-settings-form.tsx
+++ b/src/components/projects/project-settings-form.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { createClient } from '@/lib/supabase/client'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Loader2, Save, Trash2 } from 'lucide-react'
+import {
+  updateProjectSchema,
+  UpdateProjectInput,
+  PROJECT_STATUS_OPTIONS,
+  PROJECT_PRIORITY_OPTIONS,
+} from '@/lib/validators/project'
+
+type Project = {
+  id: string
+  name: string
+  description: string | null
+  status: string
+  priority: string
+  start_date: string | null
+  target_end_date: string | null
+  actual_end_date: string | null
+  budget_amount: number | null
+  tags: string[] | null
+}
+
+interface ProjectSettingsFormProps {
+  project: Project
+}
+
+export function ProjectSettingsForm({ project }: ProjectSettingsFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const router = useRouter()
+  const supabase = createClient()
+
+  const form = useForm<UpdateProjectInput>({
+    resolver: zodResolver(updateProjectSchema),
+    defaultValues: {
+      name: project.name,
+      description: project.description ?? '',
+      status: project.status as UpdateProjectInput['status'],
+      priority: project.priority as UpdateProjectInput['priority'],
+      start_date: project.start_date ?? null,
+      target_end_date: project.target_end_date ?? null,
+      actual_end_date: project.actual_end_date ?? null,
+      budget_amount: project.budget_amount ?? null,
+      tags: project.tags ?? [],
+    },
+  })
+
+  async function onSubmit(values: UpdateProjectInput) {
+    setIsSubmitting(true)
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      const { error } = await supabase
+        .from('projects')
+        .update({
+          name: values.name,
+          description: values.description || null,
+          status: values.status,
+          priority: values.priority,
+          start_date: values.start_date || null,
+          target_end_date: values.target_end_date || null,
+          actual_end_date: values.actual_end_date || null,
+          budget_amount: values.budget_amount,
+          tags: values.tags || [],
+          updated_by: user?.id,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', project.id)
+
+      if (error) throw error
+
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to update project:', error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleDelete() {
+    setIsDeleting(true)
+    try {
+      const { error } = await supabase.from('projects').delete().eq('id', project.id)
+
+      if (error) throw error
+
+      router.push('/dashboard/projects')
+      router.refresh()
+    } catch (error) {
+      console.error('Failed to delete project:', error)
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Project Settings</CardTitle>
+          <CardDescription>Update project details and configuration</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Project Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} value={field.value ?? ''} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        value={field.value ?? ''}
+                        className="min-h-[100px]"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="status"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Status</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select status" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {PROJECT_STATUS_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="priority"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Priority</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select priority" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {PROJECT_PRIORITY_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <FormField
+                  control={form.control}
+                  name="start_date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Start Date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={field.value ?? ''}
+                          onChange={(e) => field.onChange(e.target.value || null)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="target_end_date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Target End Date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={field.value ?? ''}
+                          onChange={(e) => field.onChange(e.target.value || null)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="actual_end_date"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Actual End Date</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={field.value ?? ''}
+                          onChange={(e) => field.onChange(e.target.value || null)}
+                        />
+                      </FormControl>
+                      <FormDescription>Set when project is completed</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="budget_amount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Budget (in cents)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        placeholder="e.g., 100000 for $1,000"
+                        {...field}
+                        value={field.value ?? ''}
+                        onChange={(e) =>
+                          field.onChange(e.target.value ? parseInt(e.target.value, 10) : null)
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Enter budget in cents (e.g., 100000 = $1,000.00)
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  <Save className="mr-2 h-4 w-4" />
+                  Save Changes
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card className="border-red-200">
+        <CardHeader>
+          <CardTitle className="text-red-600">Danger Zone</CardTitle>
+          <CardDescription>
+            Irreversible actions that will permanently affect this project
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div>
+              <h4 className="font-medium">Delete Project</h4>
+              <p className="text-sm text-slate-500">
+                Permanently delete this project and all associated data
+              </p>
+            </div>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" disabled={isDeleting}>
+                  {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete Project
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This action cannot be undone. This will permanently delete the project
+                    &quot;{project.name}&quot; and remove all associated team members and
+                    organization assignments.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    className="bg-red-600 hover:bg-red-700"
+                  >
+                    Delete Project
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/validators/project.ts
+++ b/src/lib/validators/project.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+
+// Project statuses
+export const PROJECT_STATUSES = [
+  'planning',
+  'active',
+  'on_hold',
+  'completed',
+  'cancelled',
+  'archived',
+] as const
+
+export const PROJECT_STATUS_OPTIONS = [
+  { value: 'planning', label: 'Planning' },
+  { value: 'active', label: 'Active' },
+  { value: 'on_hold', label: 'On Hold' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'archived', label: 'Archived' },
+] as const
+
+// Project priorities
+export const PROJECT_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const
+
+export const PROJECT_PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'critical', label: 'Critical' },
+] as const
+
+// Project member roles
+export const PROJECT_MEMBER_ROLES = [
+  'project_manager',
+  'account_manager',
+  'team_member',
+  'observer',
+] as const
+
+export const PROJECT_MEMBER_ROLE_OPTIONS = [
+  { value: 'project_manager', label: 'Project Manager' },
+  { value: 'account_manager', label: 'Account Manager' },
+  { value: 'team_member', label: 'Team Member' },
+  { value: 'observer', label: 'Observer' },
+] as const
+
+// Project organization roles
+export const PROJECT_ORG_ROLES = [
+  'client',
+  'partner',
+  'vendor',
+  'collaborator',
+] as const
+
+export const PROJECT_ORG_ROLE_OPTIONS = [
+  { value: 'client', label: 'Client' },
+  { value: 'partner', label: 'Partner' },
+  { value: 'vendor', label: 'Vendor' },
+  { value: 'collaborator', label: 'Collaborator' },
+] as const
+
+// Schema definitions
+export const projectStatusSchema = z.enum(PROJECT_STATUSES)
+export const projectPrioritySchema = z.enum(PROJECT_PRIORITIES)
+export const projectMemberRoleSchema = z.enum(PROJECT_MEMBER_ROLES)
+export const projectOrgRoleSchema = z.enum(PROJECT_ORG_ROLES)
+
+// Create project schema
+export const createProjectSchema = z.object({
+  name: z.string().min(3, { message: 'Project name must be at least 3 characters.' }).max(255),
+  description: z.string().optional(),
+  status: projectStatusSchema.default('planning'),
+  priority: projectPrioritySchema.default('medium'),
+  start_date: z.string().optional().nullable(),
+  target_end_date: z.string().optional().nullable(),
+  budget_amount: z.number().int().min(0).optional().nullable(),
+  tags: z.array(z.string()).optional().default([]),
+})
+
+export type CreateProjectInput = z.infer<typeof createProjectSchema>
+
+// Update project schema
+export const updateProjectSchema = z.object({
+  name: z.string().min(3, { message: 'Project name must be at least 3 characters.' }).max(255).optional(),
+  description: z.string().optional().nullable(),
+  status: projectStatusSchema.optional(),
+  priority: projectPrioritySchema.optional(),
+  start_date: z.string().optional().nullable(),
+  target_end_date: z.string().optional().nullable(),
+  actual_end_date: z.string().optional().nullable(),
+  budget_amount: z.number().int().min(0).optional().nullable(),
+  tags: z.array(z.string()).optional(),
+})
+
+export type UpdateProjectInput = z.infer<typeof updateProjectSchema>
+
+// Add project member schema
+export const addProjectMemberSchema = z.object({
+  user_id: z.string().uuid({ message: 'Invalid user ID.' }),
+  role: projectMemberRoleSchema.default('team_member'),
+})
+
+export type AddProjectMemberInput = z.infer<typeof addProjectMemberSchema>
+
+// Update project member schema
+export const updateProjectMemberSchema = z.object({
+  role: projectMemberRoleSchema.optional(),
+  is_active: z.boolean().optional(),
+})
+
+export type UpdateProjectMemberInput = z.infer<typeof updateProjectMemberSchema>
+
+// Add project organization schema
+export const addProjectOrganizationSchema = z.object({
+  organization_id: z.string().uuid({ message: 'Invalid organization ID.' }),
+  role: projectOrgRoleSchema.default('client'),
+})
+
+export type AddProjectOrganizationInput = z.infer<typeof addProjectOrganizationSchema>
+
+// Update project organization schema
+export const updateProjectOrganizationSchema = z.object({
+  role: projectOrgRoleSchema.optional(),
+  is_active: z.boolean().optional(),
+})
+
+export type UpdateProjectOrganizationInput = z.infer<typeof updateProjectOrganizationSchema>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,1 +1,38 @@
---: line 1: supabase: command not found
+/**
+ * Database types for KT-Portal
+ *
+ * NOTE: This file should be regenerated after schema changes using:
+ * supabase gen types typescript --local > src/types/database.ts
+ *
+ * These are placeholder types. The actual application uses 'as any' casts
+ * in many places due to the dynamic nature of the Supabase client.
+ */
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      [key: string]: {
+        Row: Record<string, unknown>
+        Insert: Record<string, unknown>
+        Update: Record<string, unknown>
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+  }
+}

--- a/supabase/migrations/20260203000005_projects_system.sql
+++ b/supabase/migrations/20260203000005_projects_system.sql
@@ -1,0 +1,339 @@
+-- Migration: Projects System
+-- Description: Core tables for project management with team and organization assignments
+-- Date: 2026-02-03
+
+-- =============================================================================
+-- PROJECTS
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+
+    -- Identifiers
+    project_number SERIAL, -- Global sequence for simplified numbering
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+
+    -- Classification
+    status VARCHAR(30) NOT NULL DEFAULT 'planning'
+        CHECK (status IN ('planning', 'active', 'on_hold', 'completed', 'cancelled', 'archived')),
+    priority VARCHAR(20) NOT NULL DEFAULT 'medium'
+        CHECK (priority IN ('low', 'medium', 'high', 'critical')),
+
+    -- Dates
+    start_date DATE,
+    target_end_date DATE,
+    actual_end_date DATE,
+
+    -- Budget
+    budget_amount INTEGER, -- in cents
+    budget_currency VARCHAR(3) DEFAULT 'USD',
+
+    -- Additional info
+    tags JSONB DEFAULT '[]',
+    metadata JSONB DEFAULT '{}',
+
+    -- Audit
+    created_by UUID NOT NULL REFERENCES public.users(id),
+    updated_by UUID REFERENCES public.users(id),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_projects_organization ON public.projects(organization_id);
+CREATE INDEX idx_projects_status ON public.projects(status);
+CREATE INDEX idx_projects_priority ON public.projects(priority);
+CREATE INDEX idx_projects_created_by ON public.projects(created_by);
+CREATE INDEX idx_projects_start_date ON public.projects(start_date);
+
+-- Comments
+COMMENT ON TABLE public.projects IS 'Main projects table for organizing work and service requests';
+COMMENT ON COLUMN public.projects.budget_amount IS 'Budget in cents for precision';
+
+-- Trigger for updated_at
+CREATE TRIGGER update_projects_updated_at
+    BEFORE UPDATE ON public.projects
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- PROJECT MEMBERS (Team Assignments)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.project_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+
+    -- Role on the project
+    role VARCHAR(30) NOT NULL DEFAULT 'team_member'
+        CHECK (role IN ('project_manager', 'account_manager', 'team_member', 'observer')),
+
+    -- Status
+    is_active BOOLEAN DEFAULT TRUE,
+
+    -- Dates
+    joined_at TIMESTAMPTZ DEFAULT NOW(),
+    left_at TIMESTAMPTZ,
+
+    -- Audit
+    assigned_by UUID REFERENCES public.users(id),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Prevent duplicate assignments
+    UNIQUE(project_id, user_id)
+);
+
+-- Indexes
+CREATE INDEX idx_project_members_project ON public.project_members(project_id);
+CREATE INDEX idx_project_members_user ON public.project_members(user_id);
+CREATE INDEX idx_project_members_role ON public.project_members(role);
+CREATE INDEX idx_project_members_active ON public.project_members(project_id) WHERE is_active = TRUE;
+
+-- Comments
+COMMENT ON TABLE public.project_members IS 'Team member assignments to projects with role-based access';
+COMMENT ON COLUMN public.project_members.role IS 'project_manager: full control, account_manager: client relationship, team_member: contributor, observer: read-only';
+
+-- Trigger for updated_at
+CREATE TRIGGER update_project_members_updated_at
+    BEFORE UPDATE ON public.project_members
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- PROJECT ORGANIZATIONS (Client Assignments)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.project_organizations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+    organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+
+    -- Role of the organization in the project
+    role VARCHAR(30) NOT NULL DEFAULT 'client'
+        CHECK (role IN ('client', 'partner', 'vendor', 'collaborator')),
+
+    -- Status
+    is_active BOOLEAN DEFAULT TRUE,
+
+    -- Audit
+    assigned_by UUID REFERENCES public.users(id),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    -- Prevent duplicate assignments
+    UNIQUE(project_id, organization_id)
+);
+
+-- Indexes
+CREATE INDEX idx_project_organizations_project ON public.project_organizations(project_id);
+CREATE INDEX idx_project_organizations_org ON public.project_organizations(organization_id);
+CREATE INDEX idx_project_organizations_active ON public.project_organizations(project_id) WHERE is_active = TRUE;
+
+-- Comments
+COMMENT ON TABLE public.project_organizations IS 'Organizations (clients, partners) associated with projects';
+
+-- Trigger for updated_at
+CREATE TRIGGER update_project_organizations_updated_at
+    BEFORE UPDATE ON public.project_organizations
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =============================================================================
+-- ROW LEVEL SECURITY (RLS)
+-- =============================================================================
+
+ALTER TABLE public.projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_organizations ENABLE ROW LEVEL SECURITY;
+
+-- -----------------------------------------------------------------------------
+-- PROJECTS POLICIES
+-- -----------------------------------------------------------------------------
+
+-- Super admins and staff can manage all projects
+CREATE POLICY "Staff can manage all projects"
+ON public.projects FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+);
+
+-- Partners can view/manage projects for their organization and client orgs
+CREATE POLICY "Partners can manage their and client projects"
+ON public.projects FOR ALL
+TO authenticated
+USING (
+    -- Check if user is partner or partner_staff
+    EXISTS (
+        SELECT 1 FROM public.users
+        WHERE id = auth.uid()
+        AND role IN ('partner', 'partner_staff')
+    )
+    AND (
+        -- Project belongs to partner's org
+        organization_id IN (
+            SELECT organization_id FROM public.users WHERE id = auth.uid()
+        )
+        OR
+        -- Project has partner's client org assigned
+        EXISTS (
+            SELECT 1 FROM public.project_organizations po
+            JOIN public.organizations o ON o.id = po.organization_id
+            WHERE po.project_id = projects.id
+            AND o.parent_org_id IN (
+                SELECT organization_id FROM public.users WHERE id = auth.uid()
+            )
+        )
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.users
+        WHERE id = auth.uid()
+        AND role IN ('partner', 'partner_staff')
+    )
+    AND organization_id IN (
+        SELECT organization_id FROM public.users WHERE id = auth.uid()
+    )
+);
+
+-- Clients can view projects where their organization is assigned
+CREATE POLICY "Clients can view their assigned projects"
+ON public.projects FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.project_organizations po
+        WHERE po.project_id = projects.id
+        AND po.organization_id IN (
+            SELECT organization_id FROM public.users WHERE id = auth.uid()
+        )
+        AND po.is_active = TRUE
+    )
+);
+
+-- -----------------------------------------------------------------------------
+-- PROJECT MEMBERS POLICIES
+-- -----------------------------------------------------------------------------
+
+-- Staff can manage all project members
+CREATE POLICY "Staff can manage all project members"
+ON public.project_members FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+);
+
+-- Partners can manage project members for their projects
+CREATE POLICY "Partners can manage project members for their projects"
+ON public.project_members FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        JOIN public.users u ON u.id = auth.uid()
+        WHERE p.id = project_members.project_id
+        AND u.role IN ('partner', 'partner_staff')
+        AND p.organization_id = u.organization_id
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        JOIN public.users u ON u.id = auth.uid()
+        WHERE p.id = project_members.project_id
+        AND u.role IN ('partner', 'partner_staff')
+        AND p.organization_id = u.organization_id
+    )
+);
+
+-- Users can view project members for projects they have access to
+CREATE POLICY "Users can view project members for accessible projects"
+ON public.project_members FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        WHERE p.id = project_members.project_id
+    )
+);
+
+-- -----------------------------------------------------------------------------
+-- PROJECT ORGANIZATIONS POLICIES
+-- -----------------------------------------------------------------------------
+
+-- Staff can manage all project organizations
+CREATE POLICY "Staff can manage all project organizations"
+ON public.project_organizations FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+);
+
+-- Partners can manage project organizations for their projects
+CREATE POLICY "Partners can manage project organizations for their projects"
+ON public.project_organizations FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        JOIN public.users u ON u.id = auth.uid()
+        WHERE p.id = project_organizations.project_id
+        AND u.role IN ('partner', 'partner_staff')
+        AND p.organization_id = u.organization_id
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        JOIN public.users u ON u.id = auth.uid()
+        WHERE p.id = project_organizations.project_id
+        AND u.role IN ('partner', 'partner_staff')
+        AND p.organization_id = u.organization_id
+    )
+);
+
+-- Users can view project organizations for projects they have access to
+CREATE POLICY "Users can view project organizations for accessible projects"
+ON public.project_organizations FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.projects p
+        WHERE p.id = project_organizations.project_id
+    )
+);
+
+-- =============================================================================
+-- ADD PROJECT TO STAFF ASSIGNMENTS
+-- =============================================================================
+
+-- Update the staff_assignments check constraint to include 'project'
+ALTER TABLE public.staff_assignments
+DROP CONSTRAINT IF EXISTS staff_assignments_assignable_type_check;
+
+ALTER TABLE public.staff_assignments
+ADD CONSTRAINT staff_assignments_assignable_type_check
+CHECK (assignable_type IN ('ticket', 'conversation', 'service_request', 'contract', 'invoice', 'project'));
+
+-- =============================================================================
+-- GRANTS
+-- =============================================================================
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.projects TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.project_members TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.project_organizations TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.projects_project_number_seq TO authenticated;


### PR DESCRIPTION
Add comprehensive project management functionality including:
- Database migration for projects, project_members, and project_organizations tables
- RLS policies for multi-tenant access control
- Project list and detail pages with filtering and search
- Create project dialog with team member and organization assignment
- Project settings form for editing project details
- Team member management panel with role assignments
- Organization assignment panel for client associations
- Zod validation schemas for project operations
- Sidebar navigation updates for project access

Roles that can create projects: super_admin, staff, partner, and partner_staff with account_manager flag

https://claude.ai/code/session_01XNP7Bz2j2iqakTuEfb6FhE