### PR TITLE
Clarify ticket visibility policy naming for organization access

### DIFF
--- a/supabase/migrations/20260202000012_client_ticket_visibility_policy.sql
+++ b/supabase/migrations/20260202000012_client_ticket_visibility_policy.sql
@@ -1,0 +1,22 @@
+-- Migration: Client Ticket Visibility Policy Rename
+-- Description: Rename "Clients can manage own tickets" to "Clients can manage organization tickets"
+--              for clarity. The policy allows clients to see ALL tickets in their organization,
+--              not just tickets they personally created.
+-- Date: 2026-02-02
+--
+-- This is a naming clarification only - no functional changes to the policy logic.
+-- Clients with role='client' can view/manage all tickets where organization_id matches
+-- their organization, enabling team collaboration on support requests.
+-- =============================================================================
+
+-- Drop the misleadingly-named policy and recreate with clearer name
+DROP POLICY IF EXISTS "Clients can manage own tickets" ON tickets;
+
+CREATE POLICY "Clients can manage organization tickets"
+  ON tickets FOR ALL
+  USING (organization_id = get_user_organization_id())
+  WITH CHECK (organization_id = get_user_organization_id());
+
+-- Add comment for documentation
+COMMENT ON POLICY "Clients can manage organization tickets" ON tickets IS
+  'Allows users to view and manage all tickets within their organization. This enables team collaboration where multiple users in the same organization can see each others support tickets.';


### PR DESCRIPTION
## Summary
Rename the ticket visibility policy from "Clients can manage own tickets" to "Clients can manage organization tickets" to better reflect the actual behavior and improve code clarity.

## Changes
- **Policy rename**: Updated misleadingly-named policy to accurately describe that clients can access all tickets within their organization, not just their own
- **Documentation**: Added inline SQL comment explaining the policy enables team collaboration across organization members
- **No functional changes**: The policy logic remains unchanged—clients with `role='client'` can still view and manage all tickets where `organization_id` matches their organization

## Details
The original policy name suggested clients could only manage tickets they personally created, which was inaccurate. The actual implementation allows any client user to see and manage all support tickets in their organization, enabling team collaboration. This migration clarifies the intent without modifying the underlying access control logic.

https://claude.ai/code/session_01Y4G1w2Ej7usE7PhsGtyh7K