### PR TITLE
White label dual highlight

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { getActiveNavHref } from "@/lib/navigation/get-active-nav-href";
 
 // Merged shape: users (id, organization_id, email, role, is_account_manager) + user_profiles (name, avatar_url, organization_name, organization_slug)
 type Profile = {
@@ -264,6 +265,18 @@ export function DashboardSidebar({
     .toUpperCase()
     .slice(0, 2);
 
+  const visibleNavGroups = navGroups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => allowedHrefs.includes(item.href)),
+    }))
+    .filter((group) => group.items.length > 0);
+
+  const activeHref = getActiveNavHref(
+    pathname,
+    visibleNavGroups.flatMap((g) => g.items.map((i) => i.href)),
+  );
+
   return (
     <aside className="hidden md:flex w-64 flex-col bg-sidebar text-sidebar-foreground flex-shrink-0 border-r border-sidebar-muted/30">
       <div className="flex h-16 items-center gap-2 px-6 border-b border-sidebar-muted/30">
@@ -290,10 +303,8 @@ export function DashboardSidebar({
       </div>
 
       <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-6">
-        {navGroups.map((group) => {
-          const items = group.items.filter((item) => allowedHrefs.includes(item.href));
-          if (items.length === 0) return null;
-
+        {visibleNavGroups.map((group) => {
+          const items = group.items;
           const isAdminGroup = group.label === "Admin";
           const showAdminBadge = isAdminGroup && role === "super_admin";
 
@@ -309,17 +320,7 @@ export function DashboardSidebar({
               </p>
               <ul className="space-y-0.5">
                 {items.map((item) => {
-                  let isActive = false;
-                  if (item.href === "/dashboard") {
-                    // Dashboard home: exact match only
-                    isActive = pathname === "/dashboard";
-                  } else if (pathname === item.href) {
-                    // Exact path match
-                    isActive = true;
-                  } else {
-                    // Nested route: check if current path starts with item path
-                    isActive = pathname.startsWith(item.href + "/");
-                  }
+                  const isActive = item.href === activeHref;
                   return (
                     <li key={item.href}>
                       <Link

--- a/src/lib/navigation/get-active-nav-href.ts
+++ b/src/lib/navigation/get-active-nav-href.ts
@@ -1,0 +1,30 @@
+function normalizePath(path: string) {
+  if (path.length > 1) return path.replace(/\/+$/, "");
+  return path;
+}
+
+/**
+ * Returns the most specific (longest) matching href for a given pathname.
+ * This prevents multiple sidebar items from being highlighted at once when
+ * both a parent and child route match.
+ */
+export function getActiveNavHref(
+  pathname: string,
+  hrefs: string[],
+  options?: { exactOnlyHrefs?: string[] },
+): string | null {
+  const exactOnly = new Set(options?.exactOnlyHrefs ?? ["/dashboard"]);
+  const p = normalizePath(pathname);
+
+  const candidates = hrefs
+    .map(normalizePath)
+    .filter((href) => {
+      if (href === "/") return p === "/";
+      if (exactOnly.has(href)) return p === href;
+      return p === href || p.startsWith(href + "/");
+    })
+    .sort((a, b) => b.length - a.length);
+
+  return candidates[0] ?? null;
+}
+

--- a/tests/unit/lib/get-active-nav-href.test.ts
+++ b/tests/unit/lib/get-active-nav-href.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { getActiveNavHref } from "@/lib/navigation/get-active-nav-href";
+
+describe("getActiveNavHref", () => {
+  it("returns the most specific (longest) matching href", () => {
+    const hrefs = ["/dashboard/settings", "/dashboard/settings/white-label"];
+    expect(getActiveNavHref("/dashboard/settings/white-label", hrefs)).toBe(
+      "/dashboard/settings/white-label",
+    );
+  });
+
+  it("matches a parent href for nested routes when no more specific match exists", () => {
+    const hrefs = ["/dashboard/tickets", "/dashboard/settings"];
+    expect(getActiveNavHref("/dashboard/tickets/123", hrefs)).toBe("/dashboard/tickets");
+  });
+
+  it("treats /dashboard as exact-only", () => {
+    const hrefs = ["/dashboard", "/dashboard/tickets"];
+    expect(getActiveNavHref("/dashboard/tickets", hrefs)).toBe("/dashboard/tickets");
+  });
+});
+


### PR DESCRIPTION
Update sidebar active link logic to highlight only the most specific matching route, preventing parent and child links from being active simultaneously.

Previously, the sidebar would highlight a link if the current URL *started with* the link's `href`. This caused issues on nested routes, such as `/dashboard/settings/white-label`, where both `/dashboard/settings` (General) and `/dashboard/settings/white-label` (White Label) would appear active. The new logic identifies the single longest matching `href` to ensure only one item is highlighted.

---
<a href="https://cursor.com/background-agent?bcId=bc-e432c43f-5705-4c8e-8ad7-d06745b5ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e432c43f-5705-4c8e-8ad7-d06745b5ded2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

