### PR TITLE
Admin user email update

### DIFF
--- a/src/components/admin/edit-user-dialog.tsx
+++ b/src/components/admin/edit-user-dialog.tsx
@@ -23,6 +23,7 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
   
   // Form state
   const [name, setName] = useState(user.user_profiles[0]?.name || '')
+  const [email, setEmail] = useState(user.email || '')
   const [role, setRole] = useState(user.role || 'client')
   
   const handleSubmit = async (e: React.FormEvent) => {
@@ -32,6 +33,7 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
     try {
       const result = await updateUser(user.id, {
         name,
+        email,
         role
       })
 
@@ -64,6 +66,23 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
               onChange={(e) => setName(e.target.value)} 
               placeholder="User's full name"
             />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="user@company.com"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+            <p className="text-xs text-muted-foreground">
+              Updating email changes the user&apos;s login email immediately.
+            </p>
           </div>
           
           <div className="space-y-2">


### PR DESCRIPTION
Add the ability for admins to update user emails from the dashboard.

This change extends the existing "Edit User" dialog to include an email field, allowing administrators to modify a user's login email. The update is applied to both Supabase Auth and the `public.users` table, with uniqueness checks and organization-level scoping enforced for non-super admin roles. An audit log entry is also created for each email update.

---
<a href="https://cursor.com/background-agent?bcId=bc-3634d097-16a3-4f09-bbd0-6d8571420463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3634d097-16a3-4f09-bbd0-6d8571420463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

