### PR TITLE
Financial management sidebar placement

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -91,6 +91,18 @@ const navGroups: { label: string; items: NavItem[] }[] = [
     ],
   },
   {
+    label: "Financial Management",
+    items: [
+      { href: "/dashboard/financials/invoicing", icon: FileText, label: "Invoicing & Revenue" },
+      { href: "/dashboard/financials/receivables", icon: DollarSign, label: "Accounts Receivable" },
+      { href: "/dashboard/financials/time-tracking", icon: Clock, label: "Time & Utilization" },
+      { href: "/dashboard/financials/subscriptions", icon: Layers, label: "Subscriptions" },
+      { href: "/dashboard/financials/cash-flow", icon: LineChart, label: "Cash & Runway" },
+      { href: "/dashboard/financials/budgeting", icon: BarChart3, label: "Budgets & Forecasts" },
+      { href: "/dashboard/financials/reports", icon: FileText, label: "Financial Reports" },
+    ],
+  },
+  {
     label: "Admin",
     items: [
       { href: "/dashboard/clients", icon: Users, label: "Clients" },
@@ -109,18 +121,6 @@ const navGroups: { label: string; items: NavItem[] }[] = [
       { href: "/dashboard/admin/notifications", icon: Bell, label: "Notifications" },
       { href: "/dashboard/admin/settings/sla", icon: Clock, label: "SLA Settings" },
       { href: "/dashboard/audit", icon: History, label: "Audit Log" },
-    ],
-  },
-  {
-    label: "Financial Management",
-    items: [
-      { href: "/dashboard/financials/invoicing", icon: FileText, label: "Invoicing & Revenue" },
-      { href: "/dashboard/financials/receivables", icon: DollarSign, label: "Accounts Receivable" },
-      { href: "/dashboard/financials/time-tracking", icon: Clock, label: "Time & Utilization" },
-      { href: "/dashboard/financials/subscriptions", icon: Layers, label: "Subscriptions" },
-      { href: "/dashboard/financials/cash-flow", icon: LineChart, label: "Cash & Runway" },
-      { href: "/dashboard/financials/budgeting", icon: BarChart3, label: "Budgets & Forecasts" },
-      { href: "/dashboard/financials/reports", icon: FileText, label: "Financial Reports" },
     ],
   },
 ];


### PR DESCRIPTION
Reorder the admin dashboard sidebar to place 'Financial Management' above 'Admin'.

---
<a href="https://cursor.com/background-agent?bcId=bc-537d82cc-bc94-45fa-9c90-d667a0dba73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-537d82cc-bc94-45fa-9c90-d667a0dba73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

