### PR TITLE
Duplicate user ID error

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -268,17 +268,19 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create user record in public.users table
+    // Ensure user record exists in public.users table.
+    // Note: DB trigger `on_auth_user_created` already inserts a row into `public.users`,
+    // so we must upsert (not insert) to avoid duplicate PK errors.
     const { error: createUserError } = await (supabaseAdmin as any)
       .from("users")
-      .insert({
+      .upsert({
         id: newAuthUser.user.id,
         email: data.email,
         role: data.role,
         organization_id: data.organization_id,
         is_account_manager: data.is_account_manager,
         status: "active",
-      });
+      }, { onConflict: "id" });
 
     if (createUserError) {
       console.error("Error creating user record:", createUserError);
@@ -290,13 +292,13 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create profile record
+    // Ensure profile record exists (trigger usually creates it)
     const { error: createProfileError } = await (supabaseAdmin as any)
       .from("profiles")
-      .insert({
+      .upsert({
         user_id: newAuthUser.user.id,
         name: data.name,
-      });
+      }, { onConflict: "user_id" });
 
     if (createProfileError) {
       console.error("Error creating profile:", createProfileError);


### PR DESCRIPTION
Update user and profile creation to use `upsert` to prevent duplicate primary key errors.

A database trigger `on_auth_user_created` already inserts rows into `public.users` and `public.profiles` when a new auth user is created, causing a duplicate primary key error when the application subsequently attempts a plain `insert`. Switching to `upsert` resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-061b9d00-621a-4088-89c2-108e2c51990c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-061b9d00-621a-4088-89c2-108e2c51990c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

