### PR TITLE
Admin email change portal

### DIFF
--- a/src/app/api/user/email/route.ts
+++ b/src/app/api/user/email/route.ts
@@ -1,10 +1,12 @@
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
 const emailChangeSchema = z.object({
   newEmail: z.string().email("Invalid email address"),
-  password: z.string().min(1, "Password is required for email change"),
+  // Password is required for non-super-admin users, but super admins may be SSO-only.
+  password: z.string().min(1, "Password is required for email change").optional(),
 });
 
 export async function POST(request: Request) {
@@ -20,6 +22,15 @@ export async function POST(request: Request) {
       );
     }
 
+    // Determine role (defaults to client if user row missing)
+    const { data: userRow } = await (supabase as any)
+      .from("users")
+      .select("id, role")
+      .eq("id", user.id)
+      .maybeSingle();
+    const role = (userRow?.role ?? "client") as string;
+    const isSuperAdmin = role === "super_admin";
+
     // Parse and validate request body
     const body = await request.json();
     const validation = emailChangeSchema.safeParse(body);
@@ -31,14 +42,15 @@ export async function POST(request: Request) {
       );
     }
 
-    const { newEmail, password } = validation.data;
+    const newEmail = String(validation.data.newEmail).trim().toLowerCase();
+    const password = validation.data.password;
 
     // Check if email is already in use
     const { data: existingUser } = await (supabase as any)
       .from("users")
       .select("id")
       .eq("email", newEmail)
-      .single();
+      .maybeSingle();
 
     if (existingUser && existingUser.id !== user.id) {
       return NextResponse.json(
@@ -47,10 +59,52 @@ export async function POST(request: Request) {
       );
     }
 
+    if (isSuperAdmin) {
+      // Super admins: update immediately (no verification email) and keep public.users in sync.
+      const supabaseAdmin = getSupabaseAdmin();
+
+      const { error: authUpdateError } = await supabaseAdmin.auth.admin.updateUserById(user.id, {
+        email: newEmail,
+        email_confirm: true as any,
+      });
+
+      if (authUpdateError) {
+        return NextResponse.json(
+          { error: authUpdateError.message || "Failed to change email" },
+          { status: 400 }
+        );
+      }
+
+      const { error: userRowUpdateError } = await (supabaseAdmin as any)
+        .from("users")
+        .update({ email: newEmail })
+        .eq("id", user.id);
+
+      if (userRowUpdateError) {
+        return NextResponse.json(
+          { error: "Email updated in auth, but failed to sync user record" },
+          { status: 500 }
+        );
+      }
+
+      return NextResponse.json({
+        success: true,
+        message: "Email updated successfully.",
+      });
+    }
+
+    // Non-super-admin: require password confirmation and use secure email change (verification email).
+    if (!password) {
+      return NextResponse.json(
+        { error: "Password is required for email change" },
+        { status: 400 }
+      );
+    }
+
     // Verify password by attempting to sign in
     const { error: signInError } = await supabase.auth.signInWithPassword({
       email: user.email!,
-      password: password,
+      password,
     });
 
     if (signInError) {

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -149,7 +149,7 @@ export default function ProfilePage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <EmailChangeForm currentEmail={user?.email || ''} />
+            <EmailChangeForm currentEmail={user?.email || ''} role={profile?.role} />
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Enable `super_admin` users to change their email via the portal without password confirmation, aligning with SSO usage and ensuring immediate updates.

Previously, `super_admin` accounts were blocked from changing their email through the portal, unlike other user roles. This update allows `super_admin` users to update their email directly, bypassing the password confirmation step and the verification email flow, which is often problematic for users relying on Single Sign-On (SSO). The change ensures that both Supabase Auth and the `public.users` table are updated simultaneously for an immediate reflection of the new email.

---
<a href="https://cursor.com/background-agent?bcId=bc-90d8f5ad-64ff-4452-b562-9a40a3595b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90d8f5ad-64ff-4452-b562-9a40a3595b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

