### PR TITLE
Fix service selection form state and validation

### DIFF
--- a/src/components/services/ServiceRequestForm.tsx
+++ b/src/components/services/ServiceRequestForm.tsx
@@ -44,6 +44,7 @@ export function ServiceRequestForm({ services }: ServiceRequestFormProps) {
   } = useForm<ServiceRequestInput>({
     resolver: zodResolver(serviceRequestSchema) as any,
     defaultValues: {
+      service_id: '',
       priority: 'medium',
     },
   })
@@ -146,7 +147,10 @@ export function ServiceRequestForm({ services }: ServiceRequestFormProps) {
                     ? 'ring-2 ring-primary bg-primary/5'
                     : 'hover:shadow-md'
                 }`}
-                onClick={() => setSelectedServiceId(service.id)}
+                onClick={() => {
+                  setSelectedServiceId(service.id)
+                  setValue('service_id', service.id)
+                }}
               >
                 <CardHeader className="pb-3">
                   <div className="flex items-start justify-between gap-2">
@@ -190,6 +194,9 @@ export function ServiceRequestForm({ services }: ServiceRequestFormProps) {
               </Card>
             ))}
           </div>
+          {errors.service_id && (
+            <p className="text-sm text-red-500 mt-2">{errors.service_id.message || 'Please select a service'}</p>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
This PR fixes the service selection functionality in the ServiceRequestForm by ensuring the form state is properly synchronized with user interactions and adding validation feedback.

## Key Changes
- Initialize `service_id` field with an empty string in form default values
- Update the form state via `setValue()` when a service card is clicked, ensuring the form's internal state matches the UI selection
- Add error message display below the service selection cards to provide user feedback when validation fails

## Implementation Details
The changes address a disconnect between the visual selection state (managed by `selectedServiceId`) and the form's actual field value. By calling `setValue('service_id', service.id)` in the click handler, we ensure that:
1. The form validation can properly check if a service has been selected
2. The selected service ID is correctly included when the form is submitted
3. Users receive clear validation feedback if they attempt to submit without selecting a service

This improves the form's reliability and user experience by making the selection state explicit in the form data.

https://claude.ai/code/session_015RwgGNoJNNNJxFQ291ScQK