### PR TITLE
feat(email): add customizable email template editing

### DIFF
--- a/src/app/dashboard/settings/email-templates/page.tsx
+++ b/src/app/dashboard/settings/email-templates/page.tsx
@@ -1,0 +1,46 @@
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+import { EmailTemplateList } from '@/components/settings/email-template-list'
+
+type UserRole = 'super_admin' | 'staff' | 'partner' | 'partner_staff' | 'client'
+
+export default async function EmailTemplatesPage() {
+  const supabase = await createServerSupabaseClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/login')
+  }
+
+  const { data: userData } = await supabase
+    .from('users')
+    .select('role, organization_id')
+    .eq('id', user.id)
+    .single()
+
+  const role = userData?.role as UserRole | null
+  const isStaffOrAdmin = role === 'staff' || role === 'super_admin'
+
+  if (!isStaffOrAdmin) {
+    redirect('/dashboard/settings')
+  }
+
+  return (
+    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight border-b pb-4">Email Templates</h2>
+        <p className="text-muted-foreground mt-2">
+          Customize email templates for notifications, invoices, and other communications.
+        </p>
+      </div>
+
+      <EmailTemplateList
+        isSuperAdmin={role === 'super_admin'}
+        organizationId={userData?.organization_id || null}
+      />
+    </div>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -33,6 +33,7 @@ import {
   FolderKanban,
   HelpCircle,
   HardDrive,
+  Mail,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -86,6 +87,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
       { href: "/dashboard/settings/white-label", icon: Palette, label: "White Label" },
       { href: "/dashboard/settings/security", icon: Shield, label: "Security" },
       { href: "/dashboard/settings/notifications", icon: Bell, label: "Notifications" },
+      { href: "/dashboard/settings/email-templates", icon: Mail, label: "Email Templates" },
       { href: "/dashboard/settings/file-storage", icon: HardDrive, label: "File Storage" },
       { href: "/dashboard/integrations", icon: Plug, label: "Integrations" },
     ],
@@ -174,6 +176,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         "/dashboard/capacity",
         ...accountBase,
         whiteLabel,
+        "/dashboard/settings/email-templates",
         "/dashboard/integrations",
         "/dashboard/clients",
         "/dashboard/projects",
@@ -195,6 +198,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         userGuide,
         "/dashboard/capacity",
         ...(isAccountManager ? accountBase : accountBaseNoInvoices),
+        "/dashboard/settings/email-templates",
         "/dashboard/projects",
         ...adminStaff,
         "/dashboard/admin/staff-management",

--- a/src/components/settings/email-template-editor.tsx
+++ b/src/components/settings/email-template-editor.tsx
@@ -1,0 +1,876 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Loader2,
+  Save,
+  Eye,
+  Code,
+  Variable,
+  ChevronDown,
+  Info,
+  Plus,
+  X,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  createEmailTemplate,
+  updateEmailTemplate,
+  renderEmailTemplate,
+  type EmailTemplate,
+  type EmailTemplateType,
+  type TemplateVariable,
+} from '@/lib/actions/email-templates'
+
+const TEMPLATE_TYPES: Array<{ value: EmailTemplateType; label: string; variables: TemplateVariable[] }> = [
+  {
+    value: 'new_user',
+    label: 'New User Welcome',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'user_name', label: 'User Name', required: true },
+      { name: 'login_url', label: 'Login URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_created',
+    label: 'Ticket Created',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'ticket_priority', label: 'Ticket Priority', required: true },
+      { name: 'created_by', label: 'Created By', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_updated',
+    label: 'Ticket Updated',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'changes', label: 'Changes Description', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_comment',
+    label: 'Ticket Comment',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'commenter_name', label: 'Commenter Name', required: true },
+      { name: 'comment_content', label: 'Comment Content', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_assigned',
+    label: 'Ticket Assigned',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'assignee_name', label: 'Assignee Name', required: true },
+      { name: 'assigned_by', label: 'Assigned By', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_resolved',
+    label: 'Ticket Resolved',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'resolution', label: 'Resolution Summary' },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'ticket_closed',
+    label: 'Ticket Closed',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_invoice',
+    label: 'New Invoice',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'client_name', label: 'Client Name', required: true },
+      { name: 'invoice_number', label: 'Invoice Number', required: true },
+      { name: 'amount', label: 'Amount', required: true },
+      { name: 'due_date', label: 'Due Date', required: true },
+      { name: 'invoice_url', label: 'Invoice URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'invoice_paid',
+    label: 'Invoice Paid',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'client_name', label: 'Client Name', required: true },
+      { name: 'invoice_number', label: 'Invoice Number', required: true },
+      { name: 'amount', label: 'Amount Paid', required: true },
+      { name: 'payment_date', label: 'Payment Date', required: true },
+      { name: 'receipt_url', label: 'Receipt URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'invoice_overdue',
+    label: 'Invoice Overdue',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'client_name', label: 'Client Name', required: true },
+      { name: 'invoice_number', label: 'Invoice Number', required: true },
+      { name: 'amount', label: 'Amount Due', required: true },
+      { name: 'days_overdue', label: 'Days Overdue', required: true },
+      { name: 'invoice_url', label: 'Invoice URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'sla_warning',
+    label: 'SLA Warning',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'ticket_priority', label: 'Ticket Priority', required: true },
+      { name: 'time_remaining', label: 'Time Remaining', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'sla_breach',
+    label: 'SLA Breach',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'ticket_number', label: 'Ticket Number', required: true },
+      { name: 'ticket_subject', label: 'Ticket Subject', required: true },
+      { name: 'ticket_priority', label: 'Ticket Priority', required: true },
+      { name: 'overdue_by', label: 'Overdue By', required: true },
+      { name: 'ticket_url', label: 'Ticket URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_project',
+    label: 'New Project',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'recipient_name', label: 'Recipient Name', required: true },
+      { name: 'project_name', label: 'Project Name', required: true },
+      { name: 'project_description', label: 'Project Description' },
+      { name: 'start_date', label: 'Start Date' },
+      { name: 'created_by', label: 'Created By', required: true },
+      { name: 'project_url', label: 'Project URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_service_request',
+    label: 'New Service Request',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'service_name', label: 'Service Name', required: true },
+      { name: 'requested_by', label: 'Requested By', required: true },
+      { name: 'organization_name', label: 'Organization Name', required: true },
+      { name: 'request_details', label: 'Request Details' },
+      { name: 'request_url', label: 'Request URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_task',
+    label: 'New Task',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'recipient_name', label: 'Recipient Name', required: true },
+      { name: 'task_name', label: 'Task Name', required: true },
+      { name: 'task_description', label: 'Task Description' },
+      { name: 'due_date', label: 'Due Date' },
+      { name: 'assigned_by', label: 'Assigned By', required: true },
+      { name: 'task_url', label: 'Task URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_tenant',
+    label: 'New Tenant',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'tenant_name', label: 'Tenant Name', required: true },
+      { name: 'admin_name', label: 'Admin Name', required: true },
+      { name: 'login_url', label: 'Login URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'new_organization',
+    label: 'New Organization',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'organization_name', label: 'Organization Name', required: true },
+      { name: 'admin_name', label: 'Admin Name', required: true },
+      { name: 'login_url', label: 'Login URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'welcome',
+    label: 'Welcome Email',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'user_name', label: 'User Name', required: true },
+      { name: 'login_url', label: 'Login URL', required: true },
+      { name: 'unsubscribe_url', label: 'Unsubscribe URL' },
+    ],
+  },
+  {
+    value: 'password_reset',
+    label: 'Password Reset',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'user_name', label: 'User Name', required: true },
+      { name: 'reset_url', label: 'Reset URL', required: true },
+      { name: 'expires_in', label: 'Expires In' },
+    ],
+  },
+  {
+    value: 'magic_link',
+    label: 'Magic Link Login',
+    variables: [
+      { name: 'portal_name', label: 'Portal Name', required: true, default: 'KT-Portal' },
+      { name: 'user_name', label: 'User Name', required: true },
+      { name: 'magic_link', label: 'Magic Link URL', required: true },
+      { name: 'expires_in', label: 'Expires In' },
+    ],
+  },
+]
+
+interface EmailTemplateEditorProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  template: EmailTemplate | null
+  isCreateMode: boolean
+  isSuperAdmin: boolean
+  organizationId: string | null
+  onSave: () => void
+  onCancel: () => void
+}
+
+export function EmailTemplateEditor({
+  open,
+  onOpenChange,
+  template,
+  isCreateMode,
+  isSuperAdmin,
+  organizationId,
+  onSave,
+  onCancel,
+}: EmailTemplateEditorProps) {
+  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit')
+  const [variablesOpen, setVariablesOpen] = useState(true)
+  const subjectRef = useRef<HTMLInputElement>(null)
+  const bodyRef = useRef<HTMLTextAreaElement>(null)
+
+  // Form state
+  const [formData, setFormData] = useState({
+    name: '',
+    template_type: 'ticket_created' as EmailTemplateType,
+    description: '',
+    subject: '',
+    body_html: '',
+    body_text: '',
+    from_name: '',
+    from_email: '',
+    reply_to: '',
+    is_default: false,
+    is_system: false,
+    variables: [] as TemplateVariable[],
+  })
+
+  // Preview state
+  const [previewVariables, setPreviewVariables] = useState<Record<string, string>>({})
+  const [renderedPreview, setRenderedPreview] = useState<{
+    subject: string
+    html: string
+  } | null>(null)
+
+  // Initialize form when template changes
+  useEffect(() => {
+    if (template) {
+      setFormData({
+        name: template.name,
+        template_type: template.template_type,
+        description: template.description || '',
+        subject: template.subject,
+        body_html: template.body_html,
+        body_text: template.body_text || '',
+        from_name: template.from_name || '',
+        from_email: template.from_email || '',
+        reply_to: template.reply_to || '',
+        is_default: template.is_default,
+        is_system: template.organization_id === null,
+        variables: template.variables || [],
+      })
+    } else if (isCreateMode) {
+      const defaultType = TEMPLATE_TYPES[0]
+      setFormData({
+        name: '',
+        template_type: defaultType.value,
+        description: '',
+        subject: '',
+        body_html: getDefaultTemplate(),
+        body_text: '',
+        from_name: '',
+        from_email: '',
+        reply_to: '',
+        is_default: false,
+        is_system: false,
+        variables: defaultType.variables,
+      })
+    }
+  }, [template, isCreateMode])
+
+  // Update variables when template type changes in create mode
+  useEffect(() => {
+    if (isCreateMode) {
+      const typeConfig = TEMPLATE_TYPES.find((t) => t.value === formData.template_type)
+      if (typeConfig) {
+        setFormData((prev) => ({
+          ...prev,
+          variables: typeConfig.variables,
+        }))
+      }
+    }
+  }, [formData.template_type, isCreateMode])
+
+  // Create mutation
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const result = await createEmailTemplate({
+        name: formData.name,
+        template_type: formData.template_type,
+        subject: formData.subject,
+        body_html: formData.body_html,
+        description: formData.description || undefined,
+        body_text: formData.body_text || undefined,
+        from_name: formData.from_name || undefined,
+        from_email: formData.from_email || undefined,
+        reply_to: formData.reply_to || undefined,
+        variables: formData.variables,
+        organization_id: formData.is_system && isSuperAdmin ? null : organizationId,
+        is_default: formData.is_default,
+      })
+      if (!result.success) throw new Error(result.error)
+      return result
+    },
+    onSuccess: () => {
+      toast.success('Template created successfully')
+      onSave()
+    },
+    onError: (error) => {
+      toast.error('Failed to create template', {
+        description: error instanceof Error ? error.message : 'Please try again',
+      })
+    },
+  })
+
+  // Update mutation
+  const updateMutation = useMutation({
+    mutationFn: async () => {
+      if (!template) throw new Error('No template to update')
+      const result = await updateEmailTemplate(template.id, {
+        name: formData.name,
+        description: formData.description || undefined,
+        subject: formData.subject,
+        body_html: formData.body_html,
+        body_text: formData.body_text || undefined,
+        from_name: formData.from_name || undefined,
+        from_email: formData.from_email || undefined,
+        reply_to: formData.reply_to || undefined,
+        variables: formData.variables,
+        is_default: formData.is_default,
+      })
+      if (!result.success) throw new Error(result.error)
+      return result
+    },
+    onSuccess: () => {
+      toast.success('Template updated successfully')
+      onSave()
+    },
+    onError: (error) => {
+      toast.error('Failed to update template', {
+        description: error instanceof Error ? error.message : 'Please try again',
+      })
+    },
+  })
+
+  // Preview mutation
+  const previewMutation = useMutation({
+    mutationFn: async () => {
+      if (!template) {
+        // Generate preview locally for new templates
+        let subject = formData.subject
+        let html = formData.body_html
+
+        for (const variable of formData.variables) {
+          const placeholder = `{{${variable.name}}}`
+          const value = previewVariables[variable.name] || variable.default || `[${variable.label}]`
+          const regex = new RegExp(placeholder.replace(/[{}]/g, '\\$&'), 'g')
+          subject = subject.replace(regex, value)
+          html = html.replace(regex, value)
+        }
+
+        return { subject, html }
+      }
+
+      const result = await renderEmailTemplate(template.id, previewVariables)
+      if (!result.success) throw new Error(result.error)
+      return result.data
+    },
+    onSuccess: (data) => {
+      if (data) {
+        setRenderedPreview({
+          subject: data.subject,
+          html: data.html,
+        })
+      }
+    },
+  })
+
+  const handleSave = () => {
+    if (!formData.name.trim()) {
+      toast.error('Template name is required')
+      return
+    }
+    if (!formData.subject.trim()) {
+      toast.error('Subject is required')
+      return
+    }
+    if (!formData.body_html.trim()) {
+      toast.error('Email body is required')
+      return
+    }
+
+    if (isCreateMode) {
+      createMutation.mutate()
+    } else {
+      updateMutation.mutate()
+    }
+  }
+
+  const insertVariable = (variableName: string, target: 'subject' | 'body') => {
+    const placeholder = `{{${variableName}}}`
+
+    if (target === 'subject' && subjectRef.current) {
+      const input = subjectRef.current
+      const start = input.selectionStart || 0
+      const end = input.selectionEnd || 0
+      const newValue = formData.subject.slice(0, start) + placeholder + formData.subject.slice(end)
+      setFormData((prev) => ({ ...prev, subject: newValue }))
+      setTimeout(() => {
+        input.focus()
+        input.setSelectionRange(start + placeholder.length, start + placeholder.length)
+      }, 0)
+    } else if (target === 'body' && bodyRef.current) {
+      const textarea = bodyRef.current
+      const start = textarea.selectionStart || 0
+      const end = textarea.selectionEnd || 0
+      const newValue = formData.body_html.slice(0, start) + placeholder + formData.body_html.slice(end)
+      setFormData((prev) => ({ ...prev, body_html: newValue }))
+      setTimeout(() => {
+        textarea.focus()
+        textarea.setSelectionRange(start + placeholder.length, start + placeholder.length)
+      }, 0)
+    }
+  }
+
+  const isSystemTemplate = template?.organization_id === null
+  const canEdit = isSuperAdmin || !isSystemTemplate || isCreateMode
+  const isSaving = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            {isCreateMode ? 'Create Email Template' : canEdit ? 'Edit Email Template' : 'View Email Template'}
+          </DialogTitle>
+          <DialogDescription>
+            {isCreateMode
+              ? 'Create a new email template for notifications.'
+              : 'Customize how your email notifications look and feel.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)} className="flex-1 overflow-hidden flex flex-col">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="edit">
+              <Code className="mr-2 h-4 w-4" />
+              Edit
+            </TabsTrigger>
+            <TabsTrigger value="preview" onClick={() => previewMutation.mutate()}>
+              <Eye className="mr-2 h-4 w-4" />
+              Preview
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="edit" className="flex-1 overflow-y-auto mt-4 space-y-6">
+            {/* Basic Info */}
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="name">Template Name</Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                  placeholder="My Custom Template"
+                  disabled={!canEdit}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="type">Template Type</Label>
+                <Select
+                  value={formData.template_type}
+                  onValueChange={(value) =>
+                    setFormData((prev) => ({ ...prev, template_type: value as EmailTemplateType }))
+                  }
+                  disabled={!isCreateMode}
+                >
+                  <SelectTrigger id="type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TEMPLATE_TYPES.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description (optional)</Label>
+              <Input
+                id="description"
+                value={formData.description}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+                placeholder="Brief description of this template"
+                disabled={!canEdit}
+              />
+            </div>
+
+            {/* Variables Section */}
+            <Collapsible open={variablesOpen} onOpenChange={setVariablesOpen}>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="w-full justify-between px-3">
+                  <div className="flex items-center gap-2">
+                    <Variable className="h-4 w-4" />
+                    <span>Available Variables</span>
+                    <Badge variant="secondary">{formData.variables.length}</Badge>
+                  </div>
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${variablesOpen ? 'rotate-180' : ''}`}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2">
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+                  <p className="text-sm text-muted-foreground flex items-center gap-2">
+                    <Info className="h-4 w-4" />
+                    Click a variable to insert it at your cursor position
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {formData.variables.map((variable) => (
+                      <div key={variable.name} className="flex items-center gap-1">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => insertVariable(variable.name, 'body')}
+                          className="text-xs font-mono"
+                          disabled={!canEdit}
+                        >
+                          {`{{${variable.name}}}`}
+                        </Button>
+                        {variable.required && (
+                          <Badge variant="destructive" className="text-xs">
+                            Required
+                          </Badge>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+
+            {/* Subject */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="subject">Subject Line</Label>
+                <div className="flex gap-1">
+                  {formData.variables.slice(0, 3).map((v) => (
+                    <Button
+                      key={v.name}
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs"
+                      onClick={() => insertVariable(v.name, 'subject')}
+                      disabled={!canEdit}
+                    >
+                      <Plus className="h-3 w-3 mr-1" />
+                      {v.name}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <Input
+                ref={subjectRef}
+                id="subject"
+                value={formData.subject}
+                onChange={(e) => setFormData((prev) => ({ ...prev, subject: e.target.value }))}
+                placeholder="Email subject line..."
+                disabled={!canEdit}
+              />
+            </div>
+
+            {/* Body HTML */}
+            <div className="space-y-2">
+              <Label htmlFor="body">Email Body (HTML)</Label>
+              <Textarea
+                ref={bodyRef}
+                id="body"
+                value={formData.body_html}
+                onChange={(e) => setFormData((prev) => ({ ...prev, body_html: e.target.value }))}
+                placeholder="<html>...</html>"
+                className="min-h-[300px] font-mono text-sm"
+                disabled={!canEdit}
+              />
+            </div>
+
+            {/* Advanced Settings */}
+            <Collapsible>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="w-full justify-between px-3">
+                  Advanced Settings
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2 space-y-4">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="from_name">From Name</Label>
+                    <Input
+                      id="from_name"
+                      value={formData.from_name}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, from_name: e.target.value }))}
+                      placeholder="KT-Portal Support"
+                      disabled={!canEdit}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="from_email">From Email</Label>
+                    <Input
+                      id="from_email"
+                      type="email"
+                      value={formData.from_email}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, from_email: e.target.value }))}
+                      placeholder="support@example.com"
+                      disabled={!canEdit}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="reply_to">Reply-To</Label>
+                    <Input
+                      id="reply_to"
+                      type="email"
+                      value={formData.reply_to}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, reply_to: e.target.value }))}
+                      placeholder="support@example.com"
+                      disabled={!canEdit}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="is_default">Set as Default</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Use this template by default for {formData.template_type.replace(/_/g, ' ')} emails
+                    </p>
+                  </div>
+                  <Switch
+                    id="is_default"
+                    checked={formData.is_default}
+                    onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, is_default: checked }))}
+                    disabled={!canEdit}
+                  />
+                </div>
+
+                {isSuperAdmin && isCreateMode && (
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="is_system">System Template</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Make this a system-wide template (available to all organizations)
+                      </p>
+                    </div>
+                    <Switch
+                      id="is_system"
+                      checked={formData.is_system}
+                      onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, is_system: checked }))}
+                    />
+                  </div>
+                )}
+              </CollapsibleContent>
+            </Collapsible>
+          </TabsContent>
+
+          <TabsContent value="preview" className="flex-1 overflow-hidden flex flex-col mt-4">
+            {/* Preview Variables */}
+            <div className="mb-4 p-4 rounded-lg border bg-muted/30">
+              <p className="text-sm font-medium mb-2">Test Variables</p>
+              <div className="grid gap-2 sm:grid-cols-3">
+                {formData.variables.slice(0, 6).map((variable) => (
+                  <div key={variable.name} className="space-y-1">
+                    <Label className="text-xs">{variable.label}</Label>
+                    <Input
+                      value={previewVariables[variable.name] || ''}
+                      onChange={(e) =>
+                        setPreviewVariables((prev) => ({ ...prev, [variable.name]: e.target.value }))
+                      }
+                      placeholder={variable.default || variable.label}
+                      className="h-8 text-sm"
+                    />
+                  </div>
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => previewMutation.mutate()}
+                className="mt-2"
+                disabled={previewMutation.isPending}
+              >
+                {previewMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Refresh Preview
+              </Button>
+            </div>
+
+            {/* Preview Frame */}
+            <div className="flex-1 overflow-hidden rounded-lg border">
+              {renderedPreview ? (
+                <div className="h-full flex flex-col">
+                  <div className="p-3 border-b bg-muted/30">
+                    <p className="text-sm">
+                      <strong>Subject:</strong> {renderedPreview.subject}
+                    </p>
+                  </div>
+                  <iframe
+                    srcDoc={renderedPreview.html}
+                    className="flex-1 w-full border-0"
+                    title="Email Preview"
+                    sandbox="allow-same-origin"
+                  />
+                </div>
+              ) : (
+                <div className="h-full flex items-center justify-center text-muted-foreground">
+                  <p>Click &quot;Preview&quot; to see how your email will look</p>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-4 border-t">
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          {canEdit && (
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              <Save className="mr-2 h-4 w-4" />
+              {isCreateMode ? 'Create Template' : 'Save Changes'}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function getDefaultTemplate(): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">{{portal_name}}</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Hello,</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 24px;">Your email content goes here.</p>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`
+}

--- a/src/components/settings/email-template-list.tsx
+++ b/src/components/settings/email-template-list.tsx
@@ -1,0 +1,465 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { createClient } from '@/lib/supabase/client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Loader2,
+  Search,
+  Mail,
+  Plus,
+  MoreVertical,
+  Pencil,
+  Copy,
+  Trash2,
+  Star,
+  Globe,
+  Building,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import {
+  deleteEmailTemplate,
+  duplicateEmailTemplate,
+  setDefaultTemplate,
+  type EmailTemplate,
+  type EmailTemplateType,
+} from '@/lib/actions/email-templates'
+import { EmailTemplateEditor } from './email-template-editor'
+
+interface EmailTemplateListProps {
+  isSuperAdmin: boolean
+  organizationId: string | null
+}
+
+const TEMPLATE_TYPE_GROUPS: Record<string, { label: string; types: EmailTemplateType[] }> = {
+  tickets: {
+    label: 'Tickets',
+    types: ['ticket_created', 'ticket_updated', 'ticket_comment', 'ticket_assigned', 'ticket_resolved', 'ticket_closed'],
+  },
+  invoices: {
+    label: 'Invoices',
+    types: ['new_invoice', 'invoice_paid', 'invoice_overdue'],
+  },
+  users: {
+    label: 'Users & Organizations',
+    types: ['new_user', 'new_tenant', 'new_organization', 'welcome'],
+  },
+  sla: {
+    label: 'SLA Alerts',
+    types: ['sla_warning', 'sla_breach'],
+  },
+  projects: {
+    label: 'Projects & Services',
+    types: ['new_project', 'new_service_request', 'new_task'],
+  },
+  auth: {
+    label: 'Authentication',
+    types: ['password_reset', 'magic_link'],
+  },
+}
+
+const getTemplateTypeDisplayName = (type: EmailTemplateType): string => {
+  const displayNames: Record<EmailTemplateType, string> = {
+    new_user: 'New User Welcome',
+    new_tenant: 'New Tenant',
+    new_organization: 'New Organization',
+    new_task: 'New Task',
+    new_service_request: 'New Service Request',
+    new_project: 'New Project',
+    new_invoice: 'New Invoice',
+    invoice_paid: 'Invoice Paid',
+    invoice_overdue: 'Invoice Overdue',
+    ticket_created: 'Ticket Created',
+    ticket_updated: 'Ticket Updated',
+    ticket_comment: 'Ticket Comment',
+    ticket_assigned: 'Ticket Assigned',
+    ticket_resolved: 'Ticket Resolved',
+    ticket_closed: 'Ticket Closed',
+    sla_warning: 'SLA Warning',
+    sla_breach: 'SLA Breach',
+    password_reset: 'Password Reset',
+    magic_link: 'Magic Link Login',
+    welcome: 'Welcome Email',
+  }
+  return displayNames[type] || type
+}
+
+export function EmailTemplateList({ isSuperAdmin, organizationId }: EmailTemplateListProps) {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate | null>(null)
+  const [isEditorOpen, setIsEditorOpen] = useState(false)
+  const [isCreateMode, setIsCreateMode] = useState(false)
+  const [templateToDelete, setTemplateToDelete] = useState<EmailTemplate | null>(null)
+  const [activeTab, setActiveTab] = useState<'all' | 'organization' | 'system'>('all')
+
+  // Fetch templates
+  const { data: templates, isLoading } = useQuery({
+    queryKey: ['email-templates'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('email_templates')
+        .select('*')
+        .eq('is_active', true)
+        .order('template_type', { ascending: true })
+        .order('is_default', { ascending: false })
+        .order('name', { ascending: true })
+
+      if (error) throw error
+      return data as EmailTemplate[]
+    },
+  })
+
+  // Delete mutation
+  const deleteMutation = useMutation({
+    mutationFn: async (templateId: string) => {
+      const result = await deleteEmailTemplate(templateId)
+      if (!result.success) throw new Error(result.error)
+      return result
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['email-templates'] })
+      toast.success('Template deleted successfully')
+      setTemplateToDelete(null)
+    },
+    onError: (error) => {
+      toast.error('Failed to delete template', {
+        description: error instanceof Error ? error.message : 'Please try again',
+      })
+    },
+  })
+
+  // Duplicate mutation
+  const duplicateMutation = useMutation({
+    mutationFn: async (templateId: string) => {
+      const result = await duplicateEmailTemplate(templateId)
+      if (!result.success) throw new Error(result.error)
+      return result
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['email-templates'] })
+      toast.success('Template duplicated successfully')
+      if (result.data) {
+        setSelectedTemplate(result.data)
+        setIsCreateMode(false)
+        setIsEditorOpen(true)
+      }
+    },
+    onError: (error) => {
+      toast.error('Failed to duplicate template', {
+        description: error instanceof Error ? error.message : 'Please try again',
+      })
+    },
+  })
+
+  // Set default mutation
+  const setDefaultMutation = useMutation({
+    mutationFn: async (templateId: string) => {
+      const result = await setDefaultTemplate(templateId)
+      if (!result.success) throw new Error(result.error)
+      return result
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['email-templates'] })
+      toast.success('Template set as default')
+    },
+    onError: (error) => {
+      toast.error('Failed to set default template', {
+        description: error instanceof Error ? error.message : 'Please try again',
+      })
+    },
+  })
+
+  // Filter templates
+  const filteredTemplates = templates?.filter((template) => {
+    // Search filter
+    const matchesSearch =
+      !searchQuery ||
+      template.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      template.subject.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      getTemplateTypeDisplayName(template.template_type).toLowerCase().includes(searchQuery.toLowerCase())
+
+    // Tab filter
+    const matchesTab =
+      activeTab === 'all' ||
+      (activeTab === 'system' && template.organization_id === null) ||
+      (activeTab === 'organization' && template.organization_id !== null)
+
+    return matchesSearch && matchesTab
+  })
+
+  // Group templates by type
+  const groupedTemplates = Object.entries(TEMPLATE_TYPE_GROUPS).map(([key, group]) => ({
+    key,
+    label: group.label,
+    templates: filteredTemplates?.filter((t) => group.types.includes(t.template_type)) || [],
+  }))
+
+  const handleEdit = (template: EmailTemplate) => {
+    setSelectedTemplate(template)
+    setIsCreateMode(false)
+    setIsEditorOpen(true)
+  }
+
+  const handleCreate = () => {
+    setSelectedTemplate(null)
+    setIsCreateMode(true)
+    setIsEditorOpen(true)
+  }
+
+  const handleEditorClose = () => {
+    setIsEditorOpen(false)
+    setSelectedTemplate(null)
+    setIsCreateMode(false)
+  }
+
+  const handleEditorSave = () => {
+    queryClient.invalidateQueries({ queryKey: ['email-templates'] })
+    handleEditorClose()
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Actions Bar */}
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search templates..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Button onClick={handleCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Template
+        </Button>
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
+        <TabsList>
+          <TabsTrigger value="all">All Templates</TabsTrigger>
+          <TabsTrigger value="organization">
+            <Building className="mr-2 h-4 w-4" />
+            Organization
+          </TabsTrigger>
+          {isSuperAdmin && (
+            <TabsTrigger value="system">
+              <Globe className="mr-2 h-4 w-4" />
+              System Defaults
+            </TabsTrigger>
+          )}
+        </TabsList>
+
+        <TabsContent value={activeTab} className="mt-6">
+          {groupedTemplates.every((g) => g.templates.length === 0) ? (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-12">
+                <Mail className="h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="text-lg font-medium">No templates found</h3>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {searchQuery ? 'Try adjusting your search' : 'Create your first email template'}
+                </p>
+                {!searchQuery && (
+                  <Button className="mt-4" onClick={handleCreate}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create Template
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-8">
+              {groupedTemplates
+                .filter((group) => group.templates.length > 0)
+                .map((group) => (
+                  <div key={group.key}>
+                    <h3 className="text-lg font-semibold mb-4">{group.label}</h3>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                      {group.templates.map((template) => (
+                        <TemplateCard
+                          key={template.id}
+                          template={template}
+                          isSuperAdmin={isSuperAdmin}
+                          organizationId={organizationId}
+                          onEdit={() => handleEdit(template)}
+                          onDuplicate={() => duplicateMutation.mutate(template.id)}
+                          onDelete={() => setTemplateToDelete(template)}
+                          onSetDefault={() => setDefaultMutation.mutate(template.id)}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Editor Dialog */}
+      <EmailTemplateEditor
+        open={isEditorOpen}
+        onOpenChange={setIsEditorOpen}
+        template={selectedTemplate}
+        isCreateMode={isCreateMode}
+        isSuperAdmin={isSuperAdmin}
+        organizationId={organizationId}
+        onSave={handleEditorSave}
+        onCancel={handleEditorClose}
+      />
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={!!templateToDelete} onOpenChange={(open) => !open && setTemplateToDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Template</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &quot;{templateToDelete?.name}&quot;? This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTemplateToDelete(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => templateToDelete && deleteMutation.mutate(templateToDelete.id)}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+interface TemplateCardProps {
+  template: EmailTemplate
+  isSuperAdmin: boolean
+  organizationId: string | null
+  onEdit: () => void
+  onDuplicate: () => void
+  onDelete: () => void
+  onSetDefault: () => void
+}
+
+function TemplateCard({
+  template,
+  isSuperAdmin,
+  organizationId,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onSetDefault,
+}: TemplateCardProps) {
+  const isSystemTemplate = template.organization_id === null
+  const canEdit = isSuperAdmin || (!isSystemTemplate && template.organization_id === organizationId)
+  const canDelete = canEdit && !template.is_default
+  const canSetDefault = canEdit && !template.is_default
+
+  return (
+    <Card className="group hover:shadow-md transition-shadow">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <CardTitle className="text-base font-medium truncate">{template.name}</CardTitle>
+              {template.is_default && (
+                <Badge variant="secondary" className="shrink-0">
+                  <Star className="mr-1 h-3 w-3" />
+                  Default
+                </Badge>
+              )}
+            </div>
+            <CardDescription className="text-xs">
+              {getTemplateTypeDisplayName(template.template_type)}
+            </CardDescription>
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onEdit}>
+                <Pencil className="mr-2 h-4 w-4" />
+                {canEdit ? 'Edit' : 'View'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onDuplicate}>
+                <Copy className="mr-2 h-4 w-4" />
+                Duplicate
+              </DropdownMenuItem>
+              {canSetDefault && (
+                <DropdownMenuItem onClick={onSetDefault}>
+                  <Star className="mr-2 h-4 w-4" />
+                  Set as Default
+                </DropdownMenuItem>
+              )}
+              {canDelete && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={onDelete} className="text-destructive">
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {isSystemTemplate ? (
+            <Badge variant="outline" className="text-xs">
+              <Globe className="mr-1 h-3 w-3" />
+              System
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-xs">
+              <Building className="mr-1 h-3 w-3" />
+              Custom
+            </Badge>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground mt-2 line-clamp-2">{template.subject}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/actions/email-templates.ts
+++ b/src/lib/actions/email-templates.ts
@@ -1,0 +1,767 @@
+'use server'
+
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+import { writeAuditLog } from '@/lib/audit'
+
+export type EmailTemplateType =
+  | 'new_user'
+  | 'new_tenant'
+  | 'new_organization'
+  | 'new_task'
+  | 'new_service_request'
+  | 'new_project'
+  | 'new_invoice'
+  | 'invoice_paid'
+  | 'invoice_overdue'
+  | 'ticket_created'
+  | 'ticket_updated'
+  | 'ticket_comment'
+  | 'ticket_assigned'
+  | 'ticket_resolved'
+  | 'ticket_closed'
+  | 'sla_warning'
+  | 'sla_breach'
+  | 'password_reset'
+  | 'magic_link'
+  | 'welcome'
+
+export type TemplateVariable = {
+  name: string
+  label: string
+  required?: boolean
+  default?: string
+}
+
+export type EmailTemplate = {
+  id: string
+  organization_id: string | null
+  template_type: EmailTemplateType
+  name: string
+  description: string | null
+  subject: string
+  body_html: string
+  body_text: string | null
+  from_name: string | null
+  from_email: string | null
+  reply_to: string | null
+  variables: TemplateVariable[]
+  is_active: boolean
+  is_default: boolean
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+const VALID_TEMPLATE_TYPES: EmailTemplateType[] = [
+  'new_user',
+  'new_tenant',
+  'new_organization',
+  'new_task',
+  'new_service_request',
+  'new_project',
+  'new_invoice',
+  'invoice_paid',
+  'invoice_overdue',
+  'ticket_created',
+  'ticket_updated',
+  'ticket_comment',
+  'ticket_assigned',
+  'ticket_resolved',
+  'ticket_closed',
+  'sla_warning',
+  'sla_breach',
+  'password_reset',
+  'magic_link',
+  'welcome'
+]
+
+/**
+ * Get all email templates accessible to the current user
+ */
+export async function getEmailTemplates(options?: {
+  templateType?: EmailTemplateType
+  includeInactive?: boolean
+  organizationId?: string | null
+}) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    let query = supabase
+      .from('email_templates')
+      .select('*')
+      .order('template_type', { ascending: true })
+      .order('is_default', { ascending: false })
+      .order('name', { ascending: true })
+
+    if (options?.templateType) {
+      query = query.eq('template_type', options.templateType)
+    }
+
+    if (!options?.includeInactive) {
+      query = query.eq('is_active', true)
+    }
+
+    if (options?.organizationId !== undefined) {
+      if (options.organizationId === null) {
+        query = query.is('organization_id', null)
+      } else {
+        query = query.eq('organization_id', options.organizationId)
+      }
+    }
+
+    const { data: templates, error } = await query
+
+    if (error) {
+      return { success: false, error: error.message }
+    }
+
+    return { success: true, data: templates as EmailTemplate[] }
+  } catch (error) {
+    console.error('Error fetching email templates:', error)
+    return { success: false, error: 'Failed to fetch email templates' }
+  }
+}
+
+/**
+ * Get a single email template by ID
+ */
+export async function getEmailTemplate(templateId: string) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    const { data: template, error } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('id', templateId)
+      .single()
+
+    if (error || !template) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    return { success: true, data: template as EmailTemplate }
+  } catch (error) {
+    console.error('Error fetching email template:', error)
+    return { success: false, error: 'Failed to fetch email template' }
+  }
+}
+
+/**
+ * Get the effective template for a given type and organization
+ * Priority: org-specific default > org-specific any > system default
+ */
+export async function getEffectiveTemplate(
+  templateType: EmailTemplateType,
+  organizationId?: string | null
+) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+
+    // First try org-specific default
+    if (organizationId) {
+      const { data: orgDefault } = await supabase
+        .from('email_templates')
+        .select('*')
+        .eq('template_type', templateType)
+        .eq('organization_id', organizationId)
+        .eq('is_default', true)
+        .eq('is_active', true)
+        .single()
+
+      if (orgDefault) {
+        return { success: true, data: orgDefault as EmailTemplate }
+      }
+
+      // Then try any org template
+      const { data: orgTemplate } = await supabase
+        .from('email_templates')
+        .select('*')
+        .eq('template_type', templateType)
+        .eq('organization_id', organizationId)
+        .eq('is_active', true)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single()
+
+      if (orgTemplate) {
+        return { success: true, data: orgTemplate as EmailTemplate }
+      }
+    }
+
+    // Fall back to system default
+    const { data: systemDefault } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('template_type', templateType)
+      .is('organization_id', null)
+      .eq('is_default', true)
+      .eq('is_active', true)
+      .single()
+
+    if (systemDefault) {
+      return { success: true, data: systemDefault as EmailTemplate }
+    }
+
+    // Last resort: any system template
+    const { data: systemTemplate } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('template_type', templateType)
+      .is('organization_id', null)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single()
+
+    if (systemTemplate) {
+      return { success: true, data: systemTemplate as EmailTemplate }
+    }
+
+    return { success: false, error: 'No template found for this type' }
+  } catch (error) {
+    console.error('Error fetching effective template:', error)
+    return { success: false, error: 'Failed to fetch template' }
+  }
+}
+
+/**
+ * Create a new email template
+ */
+export async function createEmailTemplate(data: {
+  name: string
+  template_type: EmailTemplateType
+  subject: string
+  body_html: string
+  description?: string
+  body_text?: string
+  from_name?: string
+  from_email?: string
+  reply_to?: string
+  variables?: TemplateVariable[]
+  organization_id?: string | null
+  is_default?: boolean
+}) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    // Get user profile and check permissions
+    const { data: profile } = await supabase
+      .from('users')
+      .select('organization_id, role')
+      .eq('id', user.id)
+      .single()
+
+    const role = profile?.role
+    if (role !== 'staff' && role !== 'super_admin') {
+      return { success: false, error: 'Only staff and admin can create email templates' }
+    }
+
+    // Validate required fields
+    if (!data.name || !data.subject || !data.body_html || !data.template_type) {
+      return { success: false, error: 'Name, subject, body HTML, and template type are required' }
+    }
+
+    // Validate template type
+    if (!VALID_TEMPLATE_TYPES.includes(data.template_type)) {
+      return { success: false, error: 'Invalid template type' }
+    }
+
+    // Determine organization_id
+    let organizationId = data.organization_id !== undefined ? data.organization_id : profile.organization_id
+    if (organizationId === null && role !== 'super_admin') {
+      return { success: false, error: 'Only super admin can create system templates' }
+    }
+
+    // Insert template
+    const { data: template, error: insertError } = await supabase
+      .from('email_templates')
+      .insert({
+        organization_id: organizationId,
+        template_type: data.template_type,
+        name: data.name,
+        description: data.description || null,
+        subject: data.subject,
+        body_html: data.body_html,
+        body_text: data.body_text || null,
+        from_name: data.from_name || null,
+        from_email: data.from_email || null,
+        reply_to: data.reply_to || null,
+        variables: data.variables || [],
+        is_active: true,
+        is_default: data.is_default || false,
+        created_by: user.id
+      })
+      .select()
+      .single()
+
+    if (insertError) {
+      return { success: false, error: insertError.message }
+    }
+
+    await writeAuditLog({
+      action: 'email_template.create',
+      entity_type: 'email_template',
+      entity_id: template.id,
+      new_values: {
+        name: data.name,
+        template_type: data.template_type,
+        organization_id: organizationId
+      }
+    })
+
+    revalidatePath('/dashboard/settings/email-templates')
+    return { success: true, data: template as EmailTemplate }
+  } catch (error) {
+    console.error('Error creating email template:', error)
+    return { success: false, error: 'Failed to create email template' }
+  }
+}
+
+/**
+ * Update an existing email template
+ */
+export async function updateEmailTemplate(
+  templateId: string,
+  data: {
+    name?: string
+    description?: string
+    subject?: string
+    body_html?: string
+    body_text?: string
+    from_name?: string
+    from_email?: string
+    reply_to?: string
+    variables?: TemplateVariable[]
+    is_active?: boolean
+    is_default?: boolean
+  }
+) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    // Get user profile and check permissions
+    const { data: profile } = await supabase
+      .from('users')
+      .select('organization_id, role')
+      .eq('id', user.id)
+      .single()
+
+    const role = profile?.role
+    if (role !== 'staff' && role !== 'super_admin') {
+      return { success: false, error: 'Only staff and admin can update email templates' }
+    }
+
+    // Fetch existing template
+    const { data: existingTemplate, error: fetchError } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('id', templateId)
+      .single()
+
+    if (fetchError || !existingTemplate) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    // Check permissions
+    if (role !== 'super_admin') {
+      if (existingTemplate.organization_id === null) {
+        return { success: false, error: 'Only super admin can edit system templates' }
+      }
+      if (existingTemplate.organization_id !== profile.organization_id) {
+        return { success: false, error: 'Permission denied' }
+      }
+    }
+
+    // Prepare update data
+    const updateData: Record<string, unknown> = {
+      updated_at: new Date().toISOString()
+    }
+
+    if (data.name !== undefined) updateData.name = data.name
+    if (data.description !== undefined) updateData.description = data.description
+    if (data.subject !== undefined) updateData.subject = data.subject
+    if (data.body_html !== undefined) updateData.body_html = data.body_html
+    if (data.body_text !== undefined) updateData.body_text = data.body_text
+    if (data.from_name !== undefined) updateData.from_name = data.from_name
+    if (data.from_email !== undefined) updateData.from_email = data.from_email
+    if (data.reply_to !== undefined) updateData.reply_to = data.reply_to
+    if (data.variables !== undefined) updateData.variables = data.variables
+    if (data.is_active !== undefined) updateData.is_active = data.is_active
+    if (data.is_default !== undefined) updateData.is_default = data.is_default
+
+    const { data: updatedTemplate, error: updateError } = await supabase
+      .from('email_templates')
+      .update(updateData)
+      .eq('id', templateId)
+      .select()
+      .single()
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+
+    await writeAuditLog({
+      action: 'email_template.update',
+      entity_type: 'email_template',
+      entity_id: templateId,
+      old_values: {
+        name: existingTemplate.name,
+        subject: existingTemplate.subject,
+        is_active: existingTemplate.is_active
+      },
+      new_values: updateData
+    })
+
+    revalidatePath('/dashboard/settings/email-templates')
+    revalidatePath(`/dashboard/settings/email-templates/${templateId}`)
+    return { success: true, data: updatedTemplate as EmailTemplate }
+  } catch (error) {
+    console.error('Error updating email template:', error)
+    return { success: false, error: 'Failed to update email template' }
+  }
+}
+
+/**
+ * Delete an email template (soft delete)
+ */
+export async function deleteEmailTemplate(templateId: string) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    // Get user profile and check permissions
+    const { data: profile } = await supabase
+      .from('users')
+      .select('organization_id, role')
+      .eq('id', user.id)
+      .single()
+
+    const role = profile?.role
+    if (role !== 'staff' && role !== 'super_admin') {
+      return { success: false, error: 'Only staff and admin can delete email templates' }
+    }
+
+    // Fetch existing template
+    const { data: existingTemplate, error: fetchError } = await supabase
+      .from('email_templates')
+      .select('id, name, organization_id, is_active, is_default')
+      .eq('id', templateId)
+      .single()
+
+    if (fetchError || !existingTemplate) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    // Check permissions
+    if (role !== 'super_admin') {
+      if (existingTemplate.organization_id === null) {
+        return { success: false, error: 'Only super admin can delete system templates' }
+      }
+      if (existingTemplate.organization_id !== profile.organization_id) {
+        return { success: false, error: 'Permission denied' }
+      }
+    }
+
+    if (!existingTemplate.is_active) {
+      return { success: false, error: 'Template is already deleted' }
+    }
+
+    // Soft delete
+    const { error: updateError } = await supabase
+      .from('email_templates')
+      .update({
+        is_active: false,
+        is_default: false,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', templateId)
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+
+    await writeAuditLog({
+      action: 'email_template.delete',
+      entity_type: 'email_template',
+      entity_id: templateId,
+      old_values: {
+        name: existingTemplate.name,
+        is_active: true
+      },
+      new_values: {
+        is_active: false
+      }
+    })
+
+    revalidatePath('/dashboard/settings/email-templates')
+    return { success: true, data: { id: templateId, is_active: false } }
+  } catch (error) {
+    console.error('Error deleting email template:', error)
+    return { success: false, error: 'Failed to delete email template' }
+  }
+}
+
+/**
+ * Duplicate an email template
+ */
+export async function duplicateEmailTemplate(templateId: string) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    // Get user profile and check permissions
+    const { data: profile } = await supabase
+      .from('users')
+      .select('organization_id, role')
+      .eq('id', user.id)
+      .single()
+
+    const role = profile?.role
+    if (role !== 'staff' && role !== 'super_admin') {
+      return { success: false, error: 'Only staff and admin can duplicate templates' }
+    }
+
+    // Fetch the template to duplicate
+    const { data: sourceTemplate, error: fetchError } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('id', templateId)
+      .single()
+
+    if (fetchError || !sourceTemplate) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    // Create a copy
+    const { data: newTemplate, error: insertError } = await supabase
+      .from('email_templates')
+      .insert({
+        organization_id: profile.organization_id,
+        template_type: sourceTemplate.template_type,
+        name: `${sourceTemplate.name} (Copy)`,
+        description: sourceTemplate.description,
+        subject: sourceTemplate.subject,
+        body_html: sourceTemplate.body_html,
+        body_text: sourceTemplate.body_text,
+        from_name: sourceTemplate.from_name,
+        from_email: sourceTemplate.from_email,
+        reply_to: sourceTemplate.reply_to,
+        variables: sourceTemplate.variables,
+        is_active: true,
+        is_default: false,
+        created_by: user.id
+      })
+      .select()
+      .single()
+
+    if (insertError) {
+      return { success: false, error: insertError.message }
+    }
+
+    await writeAuditLog({
+      action: 'email_template.duplicate',
+      entity_type: 'email_template',
+      entity_id: newTemplate.id,
+      new_values: {
+        name: newTemplate.name,
+        source_template_id: templateId
+      }
+    })
+
+    revalidatePath('/dashboard/settings/email-templates')
+    return { success: true, data: newTemplate as EmailTemplate }
+  } catch (error) {
+    console.error('Error duplicating email template:', error)
+    return { success: false, error: 'Failed to duplicate email template' }
+  }
+}
+
+/**
+ * Set a template as the default for its type
+ */
+export async function setDefaultTemplate(templateId: string) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    // Get user profile and check permissions
+    const { data: profile } = await supabase
+      .from('users')
+      .select('organization_id, role')
+      .eq('id', user.id)
+      .single()
+
+    const role = profile?.role
+    if (role !== 'staff' && role !== 'super_admin') {
+      return { success: false, error: 'Only staff and admin can set default templates' }
+    }
+
+    // Fetch the template
+    const { data: template, error: fetchError } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('id', templateId)
+      .single()
+
+    if (fetchError || !template) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    // Check permissions
+    if (role !== 'super_admin') {
+      if (template.organization_id === null) {
+        return { success: false, error: 'Only super admin can set system template defaults' }
+      }
+      if (template.organization_id !== profile.organization_id) {
+        return { success: false, error: 'Permission denied' }
+      }
+    }
+
+    // The trigger will handle unsetting other defaults
+    const { error: updateError } = await supabase
+      .from('email_templates')
+      .update({
+        is_default: true,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', templateId)
+
+    if (updateError) {
+      return { success: false, error: updateError.message }
+    }
+
+    await writeAuditLog({
+      action: 'email_template.set_default',
+      entity_type: 'email_template',
+      entity_id: templateId,
+      new_values: {
+        name: template.name,
+        template_type: template.template_type,
+        is_default: true
+      }
+    })
+
+    revalidatePath('/dashboard/settings/email-templates')
+    return { success: true }
+  } catch (error) {
+    console.error('Error setting default template:', error)
+    return { success: false, error: 'Failed to set default template' }
+  }
+}
+
+/**
+ * Render template with provided variables
+ */
+export async function renderEmailTemplate(
+  templateId: string,
+  variables: Record<string, string>
+) {
+  try {
+    const supabase = (await createServerSupabaseClient()) as any
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return { success: false, error: 'Unauthorized' }
+
+    const { data: template, error } = await supabase
+      .from('email_templates')
+      .select('*')
+      .eq('id', templateId)
+      .single()
+
+    if (error || !template) {
+      return { success: false, error: 'Template not found' }
+    }
+
+    // Perform variable substitution
+    let renderedSubject = template.subject
+    let renderedHtml = template.body_html
+    let renderedText = template.body_text || ''
+
+    const templateVariables = (template.variables || []) as TemplateVariable[]
+
+    for (const variable of templateVariables) {
+      const placeholder = `{{${variable.name}}}`
+      const value = variables[variable.name] || variable.default || ''
+      const regex = new RegExp(placeholder.replace(/[{}]/g, '\\$&'), 'g')
+
+      renderedSubject = renderedSubject.replace(regex, value)
+      renderedHtml = renderedHtml.replace(regex, value)
+      renderedText = renderedText.replace(regex, value)
+    }
+
+    // Also replace any variables not defined in the template schema
+    for (const [key, value] of Object.entries(variables)) {
+      const placeholder = `{{${key}}}`
+      const regex = new RegExp(placeholder.replace(/[{}]/g, '\\$&'), 'g')
+
+      renderedSubject = renderedSubject.replace(regex, value)
+      renderedHtml = renderedHtml.replace(regex, value)
+      renderedText = renderedText.replace(regex, value)
+    }
+
+    return {
+      success: true,
+      data: {
+        subject: renderedSubject,
+        html: renderedHtml,
+        text: renderedText,
+        from_name: template.from_name,
+        from_email: template.from_email,
+        reply_to: template.reply_to
+      }
+    }
+  } catch (error) {
+    console.error('Error rendering email template:', error)
+    return { success: false, error: 'Failed to render email template' }
+  }
+}
+
+/**
+ * Get template type display name
+ */
+export function getTemplateTypeDisplayName(type: EmailTemplateType): string {
+  const displayNames: Record<EmailTemplateType, string> = {
+    new_user: 'New User Welcome',
+    new_tenant: 'New Tenant',
+    new_organization: 'New Organization',
+    new_task: 'New Task',
+    new_service_request: 'New Service Request',
+    new_project: 'New Project',
+    new_invoice: 'New Invoice',
+    invoice_paid: 'Invoice Paid',
+    invoice_overdue: 'Invoice Overdue',
+    ticket_created: 'Ticket Created',
+    ticket_updated: 'Ticket Updated',
+    ticket_comment: 'Ticket Comment',
+    ticket_assigned: 'Ticket Assigned',
+    ticket_resolved: 'Ticket Resolved',
+    ticket_closed: 'Ticket Closed',
+    sla_warning: 'SLA Warning',
+    sla_breach: 'SLA Breach',
+    password_reset: 'Password Reset',
+    magic_link: 'Magic Link Login',
+    welcome: 'Welcome Email'
+  }
+  return displayNames[type] || type
+}
+
+/**
+ * Get all template types with display names
+ */
+export function getTemplateTypes(): Array<{ value: EmailTemplateType; label: string }> {
+  return VALID_TEMPLATE_TYPES.map(type => ({
+    value: type,
+    label: getTemplateTypeDisplayName(type)
+  }))
+}

--- a/supabase/migrations/20260204000003_email_templates.sql
+++ b/supabase/migrations/20260204000003_email_templates.sql
@@ -1,0 +1,588 @@
+-- Migration: Email Templates System
+-- Description: Customizable email templates for notifications with variable placeholders
+-- Date: 2026-02-04
+
+-- =============================================================================
+-- ENUMS
+-- =============================================================================
+
+CREATE TYPE email_template_type AS ENUM (
+    'new_user',
+    'new_tenant',
+    'new_organization',
+    'new_task',
+    'new_service_request',
+    'new_project',
+    'new_invoice',
+    'invoice_paid',
+    'invoice_overdue',
+    'ticket_created',
+    'ticket_updated',
+    'ticket_comment',
+    'ticket_assigned',
+    'ticket_resolved',
+    'ticket_closed',
+    'sla_warning',
+    'sla_breach',
+    'password_reset',
+    'magic_link',
+    'welcome'
+);
+
+-- =============================================================================
+-- EMAIL TEMPLATES TABLE
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS email_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE, -- NULL = system default template
+
+    -- Template identification
+    template_type email_template_type NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+
+    -- Email content
+    subject VARCHAR(500) NOT NULL,
+    body_html TEXT NOT NULL,
+    body_text TEXT, -- Plain text fallback (optional)
+
+    -- From address customization (if NULL, use system default)
+    from_name VARCHAR(255),
+    from_email VARCHAR(255),
+    reply_to VARCHAR(255),
+
+    -- Template variables definition
+    -- Example: [{"name": "user_name", "label": "User Name", "required": true, "default": "User"}]
+    variables JSONB DEFAULT '[]',
+
+    -- Template status
+    is_active BOOLEAN DEFAULT TRUE,
+    is_default BOOLEAN DEFAULT FALSE, -- Only one default per type per org (or system)
+
+    -- Metadata
+    created_by UUID REFERENCES users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_email_templates_organization ON email_templates(organization_id);
+CREATE INDEX IF NOT EXISTS idx_email_templates_type ON email_templates(template_type);
+CREATE INDEX IF NOT EXISTS idx_email_templates_active ON email_templates(is_active);
+CREATE INDEX IF NOT EXISTS idx_email_templates_default ON email_templates(is_default) WHERE is_default = TRUE;
+
+-- Unique constraint: only one default template per type per organization (or system-wide if org is NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_email_templates_unique_default
+ON email_templates(template_type, COALESCE(organization_id, '00000000-0000-0000-0000-000000000000'::uuid))
+WHERE is_default = TRUE;
+
+-- =============================================================================
+-- TRIGGERS
+-- =============================================================================
+
+-- Trigger for updated_at
+CREATE TRIGGER update_email_templates_updated_at
+    BEFORE UPDATE ON email_templates
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Function to ensure only one default per type per org
+CREATE OR REPLACE FUNCTION ensure_single_default_email_template()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.is_default = TRUE THEN
+        -- Unset other defaults for this type in the same org (or system-wide)
+        UPDATE email_templates
+        SET is_default = FALSE
+        WHERE template_type = NEW.template_type
+        AND id != NEW.id
+        AND (
+            (organization_id IS NULL AND NEW.organization_id IS NULL)
+            OR organization_id = NEW.organization_id
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER ensure_single_default_email_template_trigger
+    BEFORE INSERT OR UPDATE ON email_templates
+    FOR EACH ROW
+    WHEN (NEW.is_default = TRUE)
+    EXECUTE FUNCTION ensure_single_default_email_template();
+
+-- =============================================================================
+-- ROW LEVEL SECURITY (RLS)
+-- =============================================================================
+
+ALTER TABLE email_templates ENABLE ROW LEVEL SECURITY;
+
+-- View: Users can view templates in their organization or system default templates
+CREATE POLICY "Users can view org and system templates"
+ON email_templates FOR SELECT
+TO authenticated
+USING (
+    organization_id IS NULL -- System default templates
+    OR
+    organization_id IN (
+        SELECT organization_id FROM users WHERE id = auth.uid()
+    )
+    OR
+    -- Partners can view their client org templates
+    organization_id IN (
+        SELECT id FROM organizations
+        WHERE parent_org_id IN (SELECT organization_id FROM users WHERE id = auth.uid())
+    )
+);
+
+-- Insert: Only super_admin and staff can create templates
+CREATE POLICY "Staff can create email templates"
+ON email_templates FOR INSERT
+TO authenticated
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+    AND (
+        -- System templates only for super_admin
+        (organization_id IS NULL AND EXISTS (
+            SELECT 1 FROM users WHERE id = auth.uid() AND role = 'super_admin'
+        ))
+        OR
+        -- Org templates for staff in that org
+        organization_id IN (
+            SELECT organization_id FROM users WHERE id = auth.uid()
+        )
+    )
+);
+
+-- Update: Only super_admin and staff can update templates
+CREATE POLICY "Staff can update email templates"
+ON email_templates FOR UPDATE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+    AND (
+        (organization_id IS NULL AND EXISTS (
+            SELECT 1 FROM users WHERE id = auth.uid() AND role = 'super_admin'
+        ))
+        OR
+        organization_id IN (
+            SELECT organization_id FROM users WHERE id = auth.uid()
+        )
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+    AND (
+        (organization_id IS NULL AND EXISTS (
+            SELECT 1 FROM users WHERE id = auth.uid() AND role = 'super_admin'
+        ))
+        OR
+        organization_id IN (
+            SELECT organization_id FROM users WHERE id = auth.uid()
+        )
+    )
+);
+
+-- Delete: Only super_admin and staff can delete templates
+CREATE POLICY "Staff can delete email templates"
+ON email_templates FOR DELETE
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM users
+        WHERE id = auth.uid()
+        AND role IN ('super_admin', 'staff')
+    )
+    AND (
+        (organization_id IS NULL AND EXISTS (
+            SELECT 1 FROM users WHERE id = auth.uid() AND role = 'super_admin'
+        ))
+        OR
+        organization_id IN (
+            SELECT organization_id FROM users WHERE id = auth.uid()
+        )
+    )
+);
+
+-- =============================================================================
+-- SEED DEFAULT TEMPLATES
+-- =============================================================================
+
+-- System default templates (organization_id = NULL)
+INSERT INTO email_templates (organization_id, template_type, name, description, subject, body_html, variables, is_active, is_default)
+VALUES
+-- New User Welcome
+(NULL, 'new_user', 'New User Welcome', 'Sent when a new user account is created',
+'Welcome to {{portal_name}}!',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">Welcome to {{portal_name}}</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Hi {{user_name}},</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Your account has been created successfully. You can now access the portal and start using our services.</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 24px;">Click the button below to log in to your account:</p>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{login_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">Log In to Your Account</a>
+</td></tr></table>
+<p style="color:#6b7280;font-size:14px;line-height:1.6;margin:0;">If you have any questions, please don''t hesitate to reach out to our support team.</p>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "user_name", "label": "User Name", "required": true, "default": "User"},
+{"name": "login_url", "label": "Login URL", "required": true, "default": ""},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false, "default": ""}]'::jsonb,
+TRUE, TRUE),
+
+-- New Ticket Created
+(NULL, 'ticket_created', 'Ticket Created', 'Sent when a new support ticket is created',
+'New Ticket: {{ticket_subject}} [#{{ticket_number}}]',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">New Support Ticket</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">A new ticket has been created:</p>
+<table width="100%" style="background-color:#f9fafb;border-radius:6px;padding:16px;margin:0 0 24px;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Ticket:</strong></td><td style="color:#6b7280;padding:8px 16px;">#{{ticket_number}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Subject:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_subject}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Priority:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_priority}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Created by:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{created_by}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{ticket_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Ticket</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "ticket_number", "label": "Ticket Number", "required": true},
+{"name": "ticket_subject", "label": "Ticket Subject", "required": true},
+{"name": "ticket_priority", "label": "Ticket Priority", "required": true, "default": "Medium"},
+{"name": "created_by", "label": "Created By", "required": true},
+{"name": "ticket_url", "label": "Ticket URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- Invoice Created
+(NULL, 'new_invoice', 'New Invoice', 'Sent when a new invoice is created',
+'Invoice #{{invoice_number}} - {{amount}} Due {{due_date}}',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">New Invoice</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Hi {{client_name}},</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 24px;">A new invoice has been generated for your account:</p>
+<table width="100%" style="background-color:#f9fafb;border-radius:6px;padding:16px;margin:0 0 24px;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Invoice #:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{invoice_number}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Amount:</strong></td><td style="color:#374151;padding:8px 16px;font-weight:600;font-size:18px;">{{amount}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Due Date:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{due_date}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{invoice_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View & Pay Invoice</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "client_name", "label": "Client Name", "required": true},
+{"name": "invoice_number", "label": "Invoice Number", "required": true},
+{"name": "amount", "label": "Amount", "required": true},
+{"name": "due_date", "label": "Due Date", "required": true},
+{"name": "invoice_url", "label": "Invoice URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- Invoice Paid
+(NULL, 'invoice_paid', 'Invoice Paid', 'Sent when an invoice is paid',
+'Payment Received - Invoice #{{invoice_number}}',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#10b981 0%,#059669 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">Payment Received</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Hi {{client_name}},</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 24px;">Thank you for your payment! We''ve received your payment for the following invoice:</p>
+<table width="100%" style="background-color:#ecfdf5;border-radius:6px;padding:16px;margin:0 0 24px;border:1px solid #a7f3d0;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Invoice #:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{invoice_number}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Amount Paid:</strong></td><td style="color:#059669;padding:8px 16px;font-weight:600;font-size:18px;">{{amount}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Payment Date:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{payment_date}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{receipt_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Receipt</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "client_name", "label": "Client Name", "required": true},
+{"name": "invoice_number", "label": "Invoice Number", "required": true},
+{"name": "amount", "label": "Amount Paid", "required": true},
+{"name": "payment_date", "label": "Payment Date", "required": true},
+{"name": "receipt_url", "label": "Receipt URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- SLA Warning
+(NULL, 'sla_warning', 'SLA Warning', 'Sent when a ticket is approaching SLA deadline',
+'SLA Warning: Ticket #{{ticket_number}} approaching deadline',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#f59e0b 0%,#d97706 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">SLA Warning</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">The following ticket is approaching its SLA deadline:</p>
+<table width="100%" style="background-color:#fffbeb;border-radius:6px;padding:16px;margin:0 0 24px;border:1px solid #fcd34d;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Ticket:</strong></td><td style="color:#6b7280;padding:8px 16px;">#{{ticket_number}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Subject:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_subject}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Priority:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_priority}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Time Remaining:</strong></td><td style="color:#d97706;padding:8px 16px;font-weight:600;">{{time_remaining}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{ticket_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Ticket</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "ticket_number", "label": "Ticket Number", "required": true},
+{"name": "ticket_subject", "label": "Ticket Subject", "required": true},
+{"name": "ticket_priority", "label": "Ticket Priority", "required": true},
+{"name": "time_remaining", "label": "Time Remaining", "required": true},
+{"name": "ticket_url", "label": "Ticket URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- SLA Breach
+(NULL, 'sla_breach', 'SLA Breach', 'Sent when a ticket has breached its SLA',
+'SLA BREACH: Ticket #{{ticket_number}} is overdue',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#dc2626 0%,#b91c1c 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">SLA Breach Alert</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">The following ticket has exceeded its SLA deadline and requires immediate attention:</p>
+<table width="100%" style="background-color:#fef2f2;border-radius:6px;padding:16px;margin:0 0 24px;border:1px solid #fecaca;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Ticket:</strong></td><td style="color:#6b7280;padding:8px 16px;">#{{ticket_number}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Subject:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_subject}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Priority:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{ticket_priority}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Overdue By:</strong></td><td style="color:#dc2626;padding:8px 16px;font-weight:600;">{{overdue_by}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#dc2626 0%,#b91c1c 100%);border-radius:6px;">
+<a href="{{ticket_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Ticket Now</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "ticket_number", "label": "Ticket Number", "required": true},
+{"name": "ticket_subject", "label": "Ticket Subject", "required": true},
+{"name": "ticket_priority", "label": "Ticket Priority", "required": true},
+{"name": "overdue_by", "label": "Overdue By", "required": true},
+{"name": "ticket_url", "label": "Ticket URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- Ticket Comment
+(NULL, 'ticket_comment', 'Ticket Comment', 'Sent when a new comment is added to a ticket',
+'New comment on Ticket #{{ticket_number}}',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">New Comment</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;"><strong>{{commenter_name}}</strong> added a comment to ticket <strong>#{{ticket_number}}</strong>:</p>
+<div style="background-color:#f9fafb;border-radius:6px;padding:16px;margin:0 0 24px;border-left:4px solid #667eea;">
+<p style="color:#374151;font-size:14px;line-height:1.6;margin:0;">{{comment_content}}</p>
+</div>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{ticket_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View & Reply</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "ticket_number", "label": "Ticket Number", "required": true},
+{"name": "commenter_name", "label": "Commenter Name", "required": true},
+{"name": "comment_content", "label": "Comment Content", "required": true},
+{"name": "ticket_url", "label": "Ticket URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- New Project
+(NULL, 'new_project', 'New Project Created', 'Sent when a new project is created',
+'New Project: {{project_name}}',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">New Project</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">Hi {{recipient_name}},</p>
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 24px;">A new project has been created:</p>
+<table width="100%" style="background-color:#f9fafb;border-radius:6px;padding:16px;margin:0 0 24px;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Project:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{project_name}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Description:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{project_description}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Start Date:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{start_date}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Created by:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{created_by}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{project_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Project</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "recipient_name", "label": "Recipient Name", "required": true},
+{"name": "project_name", "label": "Project Name", "required": true},
+{"name": "project_description", "label": "Project Description", "required": false, "default": ""},
+{"name": "start_date", "label": "Start Date", "required": false},
+{"name": "created_by", "label": "Created By", "required": true},
+{"name": "project_url", "label": "Project URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE),
+
+-- New Service Request
+(NULL, 'new_service_request', 'New Service Request', 'Sent when a new service request is submitted',
+'New Service Request: {{service_name}}',
+'<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,''Segoe UI'',Roboto,''Helvetica Neue'',Arial,sans-serif;background-color:#f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;padding:40px 20px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);padding:32px;text-align:center;">
+<h1 style="color:#ffffff;margin:0;font-size:24px;font-weight:600;">New Service Request</h1>
+</td></tr>
+<tr><td style="padding:32px;">
+<p style="color:#374151;font-size:16px;line-height:1.6;margin:0 0 16px;">A new service request has been submitted:</p>
+<table width="100%" style="background-color:#f9fafb;border-radius:6px;padding:16px;margin:0 0 24px;">
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Service:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{service_name}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Requested by:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{requested_by}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Organization:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{organization_name}}</td></tr>
+<tr><td style="padding:8px 16px;"><strong style="color:#374151;">Details:</strong></td><td style="color:#6b7280;padding:8px 16px;">{{request_details}}</td></tr>
+</table>
+<table cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+<tr><td style="background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:6px;">
+<a href="{{request_url}}" style="display:inline-block;padding:14px 32px;color:#ffffff;text-decoration:none;font-weight:600;font-size:16px;">View Request</a>
+</td></tr></table>
+</td></tr>
+<tr><td style="background-color:#f9fafb;padding:24px 32px;text-align:center;border-top:1px solid #e5e7eb;">
+<p style="color:#9ca3af;font-size:12px;margin:0;">{{portal_name}} | <a href="{{unsubscribe_url}}" style="color:#9ca3af;">Manage notifications</a></p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>',
+'[{"name": "portal_name", "label": "Portal Name", "required": true, "default": "KT-Portal"},
+{"name": "service_name", "label": "Service Name", "required": true},
+{"name": "requested_by", "label": "Requested By", "required": true},
+{"name": "organization_name", "label": "Organization Name", "required": true},
+{"name": "request_details", "label": "Request Details", "required": false},
+{"name": "request_url", "label": "Request URL", "required": true},
+{"name": "unsubscribe_url", "label": "Unsubscribe URL", "required": false}]'::jsonb,
+TRUE, TRUE);


### PR DESCRIPTION
Add the ability to edit email templates for various notification types:
- New user, tenant, organization, task, service request, project
- Invoice created, paid, overdue
- Ticket created, updated, comment, assigned, resolved, closed
- SLA warning and breach alerts
- Password reset and magic link emails

Changes:
- Add email_templates table with RLS policies and default system templates
- Create server actions for CRUD operations (create, update, delete, duplicate)
- Build settings page at /dashboard/settings/email-templates
- Add template editor with HTML editing, variable insertion, and preview
- Update email provider to use templates from database with fallback
- Add navigation link for staff and super_admin roles

https://claude.ai/code/session_01P7WMKidkUZfSwAiXPTV1Nj