### PR TITLE
feat(s3): add admin UI for S3 config with DB-first credential resolution

### DIFF
--- a/src/app/api/admin/s3/config/route.ts
+++ b/src/app/api/admin/s3/config/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { resetS3Config } from "@/lib/storage/s3";
+import { z } from "zod";
+
+const configSchema = z.object({
+  aws_region: z.string().min(1).max(30).default("us-east-1"),
+  access_key_id: z.string().min(1, "Access Key ID is required"),
+  secret_access_key: z.string().min(1).optional(), // optional on updates
+  bucket_name: z.string().min(1, "Bucket name is required"),
+  kms_key_id: z.string().max(256).nullable().optional(),
+});
+
+async function requireSuperAdmin(supabase: any) {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+
+  const { data: userRow } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  const role = (userRow as { role?: string } | null)?.role;
+  if (role !== "super_admin") return null;
+
+  return user;
+}
+
+/**
+ * GET /api/admin/s3/config - Get current S3 configuration (secrets masked)
+ */
+export async function GET() {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const user = await requireSuperAdmin(supabase);
+
+    if (!user) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = supabase as unknown as { from: (table: string) => any };
+    const { data: config } = await db
+      .from("aws_s3_config")
+      .select(
+        "id, aws_region, access_key_id, bucket_name, kms_key_id, created_at, updated_at"
+      )
+      .is("organization_id", null)
+      .maybeSingle();
+
+    // Also report whether env vars are set (as a fallback indicator)
+    const envConfigured =
+      !!process.env.AWS_S3_BUCKET_NAME &&
+      !!process.env.AWS_ACCESS_KEY_ID &&
+      !!process.env.AWS_SECRET_ACCESS_KEY;
+
+    return NextResponse.json({
+      config: config
+        ? {
+            ...config,
+            // Mask the access key for display
+            access_key_id_masked: maskKey(config.access_key_id),
+          }
+        : null,
+      envConfigured,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/admin/s3/config - Save or update S3 configuration
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const user = await requireSuperAdmin(supabase);
+
+    if (!user) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = await request.json().catch(() => null);
+    const validation = configSchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: validation.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const db = supabase as unknown as { from: (table: string) => any };
+
+    // Check for existing global config
+    const { data: existing } = await db
+      .from("aws_s3_config")
+      .select("id")
+      .is("organization_id", null)
+      .maybeSingle();
+
+    if (existing) {
+      // Update
+      const updateData: Record<string, unknown> = {
+        aws_region: validation.data.aws_region,
+        access_key_id: validation.data.access_key_id,
+        bucket_name: validation.data.bucket_name,
+        updated_by: user.id,
+      };
+
+      if (validation.data.secret_access_key) {
+        updateData.secret_access_key = validation.data.secret_access_key;
+      }
+
+      if (validation.data.kms_key_id !== undefined) {
+        updateData.kms_key_id = validation.data.kms_key_id || null;
+      }
+
+      const { error } = await db
+        .from("aws_s3_config")
+        .update(updateData)
+        .eq("id", existing.id);
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    } else {
+      // Insert new
+      if (!validation.data.secret_access_key) {
+        return NextResponse.json(
+          { error: "Secret Access Key is required for initial setup" },
+          { status: 400 }
+        );
+      }
+
+      const { error } = await db.from("aws_s3_config").insert({
+        aws_region: validation.data.aws_region,
+        access_key_id: validation.data.access_key_id,
+        secret_access_key: validation.data.secret_access_key,
+        bucket_name: validation.data.bucket_name,
+        kms_key_id: validation.data.kms_key_id || null,
+        organization_id: null,
+        created_by: user.id,
+        updated_by: user.id,
+      });
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+
+    // Clear cached S3 config so next request picks up the new credentials
+    resetS3Config();
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/admin/s3/config - Remove S3 configuration (falls back to env vars)
+ */
+export async function DELETE() {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const user = await requireSuperAdmin(supabase);
+
+    if (!user) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const db = supabase as unknown as { from: (table: string) => any };
+    const { error } = await db
+      .from("aws_s3_config")
+      .delete()
+      .is("organization_id", null);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Clear cached S3 config so next request falls back to env vars
+    resetS3Config();
+
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+function maskKey(key: string): string {
+  if (!key || key.length < 8) return "****";
+  return key.slice(0, 4) + "****" + key.slice(-4);
+}

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import {
   uploadObject,
-  BUCKET_NAME,
+  getBucketName,
   sanitizeS3KeyPart,
 } from "@/lib/storage/s3";
 import { normalizeS3Prefix } from "@/lib/file-sync/s3-prefix";
@@ -221,7 +221,7 @@ export async function POST(request: NextRequest) {
         name: file.name,
         mime_type: file.type,
         size_bytes: file.size,
-        s3_bucket: BUCKET_NAME,
+        s3_bucket: (await getBucketName()),
         s3_key: s3Key,
         folder: folder,
         synced_at: new Date().toISOString(),

--- a/src/app/dashboard/files/page.tsx
+++ b/src/app/dashboard/files/page.tsx
@@ -48,10 +48,20 @@ export default async function FilesPage() {
     );
   }
 
-  const awsConfigured =
+  const awsEnvConfigured =
     !!process.env.AWS_S3_BUCKET_NAME &&
     !!process.env.AWS_ACCESS_KEY_ID &&
     !!process.env.AWS_SECRET_ACCESS_KEY;
+
+  // Also check if S3 is configured via the admin DB settings
+  const db = supabase as unknown as { from: (table: string) => any };
+  const { data: s3DbConfig } = await db
+    .from("aws_s3_config")
+    .select("id")
+    .is("organization_id", null)
+    .maybeSingle();
+
+  const awsConfigured = awsEnvConfigured || !!s3DbConfig;
 
   const isPrivileged =
     profile.role === "super_admin" || profile.role === "staff";

--- a/src/components/admin/s3-config-form.tsx
+++ b/src/components/admin/s3-config-form.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  AlertCircle,
+  Eye,
+  EyeOff,
+  CheckCircle2,
+  Info,
+} from "lucide-react";
+
+const MASKED_SECRET = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022";
+
+const s3ConfigSchema = z.object({
+  aws_region: z.string().min(1, "AWS Region is required"),
+  access_key_id: z.string().min(1, "Access Key ID is required"),
+  secret_access_key: z.string().min(1, "Secret Access Key is required"),
+  bucket_name: z.string().min(1, "Bucket name is required"),
+  kms_key_id: z.string().optional(),
+});
+
+type S3ConfigFormData = z.infer<typeof s3ConfigSchema>;
+
+interface S3ConfigFormProps {
+  existingConfig: {
+    id: string;
+    aws_region: string;
+    access_key_id_masked: string;
+    bucket_name: string;
+    kms_key_id: string | null;
+    created_at: string;
+    updated_at: string;
+  } | null;
+  envConfigured: boolean;
+}
+
+export function S3ConfigForm({
+  existingConfig,
+  envConfigured,
+}: S3ConfigFormProps) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showSecret, setShowSecret] = useState(false);
+  const router = useRouter();
+
+  const hasExistingConfig = !!existingConfig;
+
+  const form = useForm<S3ConfigFormData>({
+    resolver: zodResolver(s3ConfigSchema),
+    defaultValues: {
+      aws_region: existingConfig?.aws_region || "us-east-1",
+      access_key_id: existingConfig?.access_key_id_masked?.replace(/\*/g, "") || "",
+      secret_access_key: hasExistingConfig ? MASKED_SECRET : "",
+      bucket_name: existingConfig?.bucket_name || "",
+      kms_key_id: existingConfig?.kms_key_id || "",
+    },
+  });
+
+  const onSubmit = async (data: S3ConfigFormData) => {
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const payload: Record<string, unknown> = {
+        aws_region: data.aws_region,
+        access_key_id: data.access_key_id,
+        bucket_name: data.bucket_name,
+        kms_key_id: data.kms_key_id || null,
+      };
+
+      // Only include secret if it was changed from the masked value
+      if (data.secret_access_key !== MASKED_SECRET) {
+        payload.secret_access_key = data.secret_access_key;
+      }
+
+      const response = await fetch("/api/admin/s3/config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result.error || "Failed to save configuration");
+      }
+
+      router.push(
+        "/dashboard/admin/settings/integrations?success=s3_config_saved"
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/admin/s3/config", {
+        method: "DELETE",
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(result.error || "Failed to delete configuration");
+      }
+
+      router.push(
+        "/dashboard/admin/settings/integrations?success=s3_config_deleted"
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <Badge
+          variant="outline"
+          className={
+            hasExistingConfig
+              ? "bg-green-500/10 text-green-600 border-green-500/30"
+              : "bg-muted text-muted-foreground"
+          }
+        >
+          {hasExistingConfig ? (
+            <>
+              <CheckCircle2 className="w-3 h-3 mr-1" />
+              DB Config Active
+            </>
+          ) : (
+            "No DB Config"
+          )}
+        </Badge>
+        <Badge
+          variant="outline"
+          className={
+            envConfigured
+              ? "bg-blue-500/10 text-blue-600 border-blue-500/30"
+              : "bg-muted text-muted-foreground"
+          }
+        >
+          {envConfigured ? (
+            <>
+              <CheckCircle2 className="w-3 h-3 mr-1" />
+              Env Vars Set
+            </>
+          ) : (
+            "No Env Vars"
+          )}
+        </Badge>
+      </div>
+
+      {envConfigured && !hasExistingConfig && (
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            S3 is currently configured via environment variables. You can
+            optionally save credentials here to manage them from the portal
+            instead.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="aws_region"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>AWS Region *</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="us-east-1"
+                      disabled={isSaving}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    e.g. us-east-1, eu-west-1
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bucket_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>S3 Bucket Name *</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="my-portal-files"
+                      disabled={isSaving}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    The bucket where client files are stored
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <FormField
+            control={form.control}
+            name="access_key_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Access Key ID *</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="AKIA..."
+                    disabled={isSaving}
+                  />
+                </FormControl>
+                <FormDescription>
+                  IAM access key with S3 permissions
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="secret_access_key"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Secret Access Key *</FormLabel>
+                <FormControl>
+                  <div className="relative">
+                    <Input
+                      {...field}
+                      type={showSecret ? "text" : "password"}
+                      placeholder={
+                        hasExistingConfig
+                          ? "Leave unchanged or enter new key"
+                          : "Your AWS Secret Access Key"
+                      }
+                      disabled={isSaving}
+                      className="pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowSecret(!showSecret)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                      {showSecret ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </FormControl>
+                <FormDescription>
+                  {hasExistingConfig
+                    ? "The existing secret is hidden. Leave unchanged to keep it, or enter a new one."
+                    : "This will be stored securely in the database."}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="kms_key_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>KMS Key ID (optional)</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="arn:aws:kms:us-east-1:123456789:key/..."
+                    disabled={isSaving}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Set to enable SSE-KMS encryption. Leave blank for default
+                  SSE-S3 (AES-256) encryption.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex gap-4 pt-4">
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : hasExistingConfig ? (
+                "Update Configuration"
+              ) : (
+                "Save Configuration"
+              )}
+            </Button>
+
+            {hasExistingConfig && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Deleting...
+                      </>
+                    ) : (
+                      "Delete Configuration"
+                    )}
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Delete S3 Configuration?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will remove the stored AWS S3 credentials.
+                      {envConfigured
+                        ? " The system will fall back to environment variables."
+                        : " File uploads will stop working until new credentials are configured."}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleDelete}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      Delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/supabase/migrations/20260208000001_aws_s3_config.sql
+++ b/supabase/migrations/20260208000001_aws_s3_config.sql
@@ -1,0 +1,72 @@
+-- Migration: AWS S3 Configuration
+-- Created: 2026-02-08
+-- Description: Add table to store AWS S3 credentials in admin settings,
+--   allowing super_admins to configure S3 from the portal UI instead of
+--   relying solely on environment variables.
+
+-- ============================================================================
+-- 1. Create aws_s3_config table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS aws_s3_config (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- AWS S3 Credentials
+  aws_region TEXT NOT NULL DEFAULT 'us-east-1',
+  access_key_id TEXT NOT NULL,
+  secret_access_key TEXT NOT NULL,
+  bucket_name TEXT NOT NULL,
+  kms_key_id TEXT, -- optional: set to enable SSE-KMS instead of SSE-S3
+
+  -- Optional: Organization-specific config (NULL = global / platform-wide config)
+  organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE,
+
+  -- Metadata
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES auth.users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES auth.users(id),
+
+  -- One config per org (or one global)
+  UNIQUE(organization_id)
+);
+
+COMMENT ON TABLE aws_s3_config IS
+  'Stores AWS S3 credentials. Global config (organization_id NULL) is the platform default. Per-org configs override the global one.';
+
+-- ============================================================================
+-- 2. RLS policies (super_admin only)
+-- ============================================================================
+
+ALTER TABLE aws_s3_config ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Super admins can view S3 configs"
+  ON aws_s3_config FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid()
+      AND role = 'super_admin'
+    )
+  );
+
+CREATE POLICY "Super admins can manage S3 configs"
+  ON aws_s3_config FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid()
+      AND role = 'super_admin'
+    )
+  );
+
+-- ============================================================================
+-- 3. Indexes and triggers
+-- ============================================================================
+
+CREATE INDEX idx_aws_s3_config_org ON aws_s3_config(organization_id);
+
+CREATE TRIGGER update_aws_s3_config_updated_at
+  BEFORE UPDATE ON aws_s3_config
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
- Add aws_s3_config table migration with RLS (super_admin only)
- Add /api/admin/s3/config CRUD route (GET/POST/DELETE)
- Add S3ConfigForm component on admin integrations page
- Refactor S3 lib to resolve credentials from DB first, env vars as fallback
- Cache resolved config per serverless invocation with resetS3Config() for invalidation
- Remove legacy module-level constants (s3Client, BUCKET_NAME, SSE_ALGORITHM)
- All S3 operations now use async resolveConfig() + buildClient() + sseParams()
- Update files page to detect DB-based S3 config in addition to env vars

https://claude.ai/code/session_01EAkhDfZyp3HWqWSFKYtY5u