### PR TITLE
fix(db): change profiles->users queries and fix FK hints across 11 files

### DIFF
--- a/src/app/api/admin/quickbooks/config/route.ts
+++ b/src/app/api/admin/quickbooks/config/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
 
     // Check if user is super admin
     const { data: profile } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role")
       .eq("id", user.id)
       .single();
@@ -150,7 +150,7 @@ export async function DELETE(request: NextRequest) {
 
     // Check if user is super admin
     const { data: profile } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role")
       .eq("id", user.id)
       .single();
@@ -223,7 +223,7 @@ export async function GET(request: NextRequest) {
 
     // Check if user is super admin
     const { data: profile } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role")
       .eq("id", user.id)
       .single();

--- a/src/app/api/invoices/[id]/payments/manual/route.ts
+++ b/src/app/api/invoices/[id]/payments/manual/route.ts
@@ -30,7 +30,7 @@ export async function POST(
 
     // Get user profile to check authorization
     const { data: profile, error: profileError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role, is_account_manager")
       .eq("id", user.id)
       .single();
@@ -86,7 +86,7 @@ export async function POST(
 
     // Verify user has access to this invoice's organization
     const { data: userOrg, error: userOrgError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("organization_id")
       .eq("id", user.id)
       .single();
@@ -235,9 +235,10 @@ export async function GET(
           recorded_by,
           notes,
           created_at,
-          recorded_by_profile:profiles!invoice_payments_recorded_by_fkey (
-            name,
-            email
+          recorded_by_profile:users!invoice_payments_recorded_by_fkey (
+            id,
+            email,
+            profiles:profiles(name)
           )
         )
       `

--- a/src/app/api/quickbooks/connect/route.ts
+++ b/src/app/api/quickbooks/connect/route.ts
@@ -21,9 +21,9 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get user profile
+    // Get user role and org
     const { data: profile, error: profileError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role, is_account_manager, organization_id")
       .eq("id", user.id)
       .single();

--- a/src/app/api/quickbooks/disconnect/route.ts
+++ b/src/app/api/quickbooks/disconnect/route.ts
@@ -19,9 +19,9 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get user profile
+    // Get user role and org
     const { data: profile, error: profileError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role, is_account_manager, organization_id")
       .eq("id", user.id)
       .single();

--- a/src/app/api/quickbooks/sync/invoice/[id]/route.ts
+++ b/src/app/api/quickbooks/sync/invoice/[id]/route.ts
@@ -27,9 +27,9 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get user profile
+    // Get user role and org
     const { data: profile, error: profileError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role, is_account_manager, organization_id")
       .eq("id", user.id)
       .single();

--- a/src/app/api/quickbooks/sync/payment/[id]/route.ts
+++ b/src/app/api/quickbooks/sync/payment/[id]/route.ts
@@ -27,9 +27,9 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Get user profile
+    // Get user role and org
     const { data: profile, error: profileError } = await supabase
-      .from("profiles")
+      .from("users")
       .select("role, is_account_manager, organization_id")
       .eq("id", user.id)
       .single();

--- a/src/app/api/zapier/tickets/route.ts
+++ b/src/app/api/zapier/tickets/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
 
     let query = supabaseAdmin
       .from("tickets")
-      .select("*, created_by:profiles!created_by(id, name, email)")
+      .select("*, created_by_user:users!tickets_created_by_fkey(id, email, profiles:profiles(name))")
       .eq("organization_id", apiKeyContext.organizationId)
       .order("created_at", { ascending: false })
       .limit(limit);

--- a/src/app/dashboard/admin/settings/integrations/page.tsx
+++ b/src/app/dashboard/admin/settings/integrations/page.tsx
@@ -29,9 +29,9 @@ export default async function AdminIntegrationsSettingsPage({
     return <div>Unauthorized</div>;
   }
 
-  // Get user profile
+  // Get user role
   const { data: profile } = await supabase
-    .from("profiles")
+    .from("users")
     .select("role")
     .eq("id", user.id)
     .single();

--- a/src/app/dashboard/invoices/[id]/page.tsx
+++ b/src/app/dashboard/invoices/[id]/page.tsx
@@ -70,9 +70,10 @@ export default async function InvoiceDetailPage({ params }: PageProps) {
         payment_source,
         notes,
         created_at,
-        recorded_by_profile:profiles!invoice_payments_recorded_by_fkey(
-          name,
-          email
+        recorded_by_profile:users!invoice_payments_recorded_by_fkey(
+          id,
+          email,
+          profiles:profiles(name)
         )
       )
     `)
@@ -85,7 +86,7 @@ export default async function InvoiceDetailPage({ params }: PageProps) {
 
   // Verify user can access this invoice and get their role
   const { data: profile } = await supabase
-    .from('profiles')
+    .from('users')
     .select('organization_id, role, is_account_manager')
     .eq('id', user.id)
     .single()
@@ -346,7 +347,7 @@ export default async function InvoiceDetailPage({ params }: PageProps) {
 
                       {payment.payment_source === 'manual' && payment.recorded_by_profile && (
                         <p className="text-xs text-muted-foreground">
-                          Recorded by {payment.recorded_by_profile.name || payment.recorded_by_profile.email}
+                          Recorded by {payment.recorded_by_profile.profiles?.name || payment.recorded_by_profile.email}
                         </p>
                       )}
                     </div>

--- a/src/app/dashboard/settings/integrations/page.tsx
+++ b/src/app/dashboard/settings/integrations/page.tsx
@@ -29,9 +29,9 @@ export default async function IntegrationsSettingsPage({
     return <div>Unauthorized</div>;
   }
 
-  // Get user profile
+  // Get user role and org
   const { data: profile } = await supabase
-    .from("profiles")
+    .from("users")
     .select("role, is_account_manager, organization_id")
     .eq("id", user.id)
     .single();


### PR DESCRIPTION
After the users/profiles restructure, many files still queried the profiles table for columns (role, email, organization_id, is_account_manager) that now only exist on the users table. This caused "column does not exist" errors at runtime.

Changes:
- Fix .from("profiles") to .from("users") for role/org queries in: quickbooks config, connect, disconnect, sync routes, invoices page, manual payments, integrations settings pages
- Fix profiles! FK hints to users! in invoice payments joins and zapier tickets route, with nested profiles:profiles(name) for display
- Guard organization_files migration with IF EXISTS check

https://claude.ai/code/session_01MccjsbB59pVRwTcRPj4gjW