### PR TITLE
feat(tickets): add optional due date picker to ticket creation form

### DIFF
--- a/src/components/tickets/create-ticket-form.tsx
+++ b/src/components/tickets/create-ticket-form.tsx
@@ -27,8 +27,12 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-import { Loader2, AlertCircle, CheckCircle2, ChevronLeft } from 'lucide-react'
+import { Loader2, AlertCircle, CheckCircle2, ChevronLeft, CalendarIcon } from 'lucide-react'
+import { format } from 'date-fns'
 import Link from 'next/link'
+import { cn } from '@/lib/cn'
+import { Calendar } from '@/components/ui/calendar'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { TicketFileUpload, type UploadedFile } from './ticket-file-upload'
 
 type FormValues = CreateTicketInput
@@ -52,6 +56,7 @@ export function CreateTicketForm({ organizationId, userId }: CreateTicketFormPro
       description: '',
       priority: 'medium',
       category: 'technical_support',
+      due_date: null,
     },
   })
 
@@ -78,6 +83,7 @@ export function CreateTicketForm({ organizationId, userId }: CreateTicketFormPro
           category: values.category,
           status: 'new',
           tags: [],
+          client_due_date: values.due_date || null,
         })
         .select()
         .single()
@@ -219,6 +225,46 @@ export function CreateTicketForm({ organizationId, userId }: CreateTicketFormPro
               )}
             />
           </div>
+
+          <FormField
+            control={form.control}
+            name="due_date"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel className="text-slate-700 font-semibold">Requested Due Date</FormLabel>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <FormControl>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={cn(
+                          'h-12 w-full pl-3 text-left font-normal',
+                          !field.value && 'text-muted-foreground'
+                        )}
+                      >
+                        {field.value ? format(new Date(field.value + 'T00:00:00'), 'PPP') : 'No due date'}
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                      </Button>
+                    </FormControl>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      mode="single"
+                      selected={field.value ? new Date(field.value + 'T00:00:00') : undefined}
+                      onSelect={(date) => {
+                        field.onChange(date ? format(date, 'yyyy-MM-dd') : null)
+                      }}
+                      disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+                <FormDescription>Optional. Let us know if you need this resolved by a specific date.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
           <FormField
             control={form.control}

--- a/src/lib/validators/ticket.ts
+++ b/src/lib/validators/ticket.ts
@@ -8,6 +8,7 @@ export const createTicketSchema = z.object({
   description: z.string().min(20, { message: 'Description must be at least 20 characters.' }),
   priority: ticketPrioritySchema,
   category: z.string().min(1, { message: 'Please select a category.' }),
+  due_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format').nullable().optional(),
 })
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>

--- a/supabase/migrations/20260208200001_ticket_client_due_date.sql
+++ b/supabase/migrations/20260208200001_ticket_client_due_date.sql
@@ -1,0 +1,11 @@
+-- Migration: Add client-requested due date to tickets
+-- Description: Optional due date that clients can set when creating tickets
+-- Date: 2026-02-08
+
+ALTER TABLE tickets
+ADD COLUMN IF NOT EXISTS client_due_date DATE;
+
+COMMENT ON COLUMN tickets.client_due_date IS 'Optional due date requested by the client when creating the ticket';
+
+-- Reload PostgREST schema cache
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Adds a client-requested due date field to the support ticket form:
- New migration adding client_due_date DATE column to tickets table
- Zod validator updated with optional due_date field (YYYY-MM-DD format)
- Calendar date picker UI using Popover + Calendar components
- Dates in the past are disabled; field is optional with clear labeling

https://claude.ai/code/session_01MccjsbB59pVRwTcRPj4gjW