### PR TITLE
fix(projects): restrict task assignment to project members only

### DIFF
--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -256,21 +256,15 @@ export default async function ProjectDetailPage({
   const tasksDone = projectTasks.filter((t: any) => t.status === 'done').length
   const tasksTotal = projectTasks.length
 
-  // Members for task assignment (active project members + available staff)
-  const taskAssignees = [
-    ...(project.project_members ?? [])
-      .filter((m: any) => m.is_active && m.user)
-      .map((m: any) => ({
-        id: m.user.id,
-        email: m.user.email,
-        role: m.user.role,
-        profiles: m.user.profiles,
-      })),
-    ...availableStaff.filter(
-      (s: any) =>
-        !(project.project_members ?? []).some((m: any) => m.user_id === s.id)
-    ),
-  ]
+  // Only active project members can be assigned to tasks
+  const taskAssignees = (project.project_members ?? [])
+    .filter((m: any) => m.is_active && m.user)
+    .map((m: any) => ({
+      id: m.user.id,
+      email: m.user.email,
+      role: m.user.role,
+      profiles: m.user.profiles,
+    }))
 
   return (
     <div className="space-y-6">

--- a/src/components/projects/project-tasks-list.tsx
+++ b/src/components/projects/project-tasks-list.tsx
@@ -374,23 +374,29 @@ export function ProjectTasksList({
                     </div>
                     <div>
                       <label className="text-sm font-medium">Assign To</label>
-                      <Select
-                        value={newTask.assigned_to}
-                        onValueChange={(v) =>
-                          setNewTask((prev) => ({ ...prev, assigned_to: v }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Unassigned" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {members.map((m) => (
-                            <SelectItem key={m.id} value={m.id}>
-                              {m.profiles?.name ?? m.email}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      {members.length > 0 ? (
+                        <Select
+                          value={newTask.assigned_to}
+                          onValueChange={(v) =>
+                            setNewTask((prev) => ({ ...prev, assigned_to: v }))
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Unassigned" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {members.map((m) => (
+                              <SelectItem key={m.id} value={m.id}>
+                                {m.profiles?.name ?? m.email}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <p className="text-sm text-slate-500 mt-1">
+                          Add members to the project Team tab first.
+                        </p>
+                      )}
                     </div>
                     <div>
                       <label className="text-sm font-medium">Due Date</label>


### PR DESCRIPTION
Tasks can now only be assigned to active project members, not all available staff. Shows a helpful message directing users to the Team tab when no members have been added yet.

https://claude.ai/code/session_014RsK63goXvADF4zVxxjt4T