### PR TITLE
fix(projects): display budget in dollars instead of cents

### DIFF
--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -551,7 +551,7 @@ export default async function ProjectDetailPage({
                     <div className="flex justify-between py-2 border-b border-slate-100">
                       <span className="text-slate-500">Budget</span>
                       <span className="font-medium">
-                        ${(project.budget_amount / 100).toLocaleString()}
+                        ${(project.budget_amount / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                       </span>
                     </div>
                   )}

--- a/src/components/projects/project-settings-form.tsx
+++ b/src/components/projects/project-settings-form.tsx
@@ -83,7 +83,7 @@ export function ProjectSettingsForm({ project }: ProjectSettingsFormProps) {
       start_date: project.start_date ?? null,
       target_end_date: project.target_end_date ?? null,
       actual_end_date: project.actual_end_date ?? null,
-      budget_amount: project.budget_amount ?? null,
+      budget_amount: project.budget_amount != null ? project.budget_amount / 100 : null,
       tags: project.tags ?? [],
     },
   })
@@ -105,7 +105,7 @@ export function ProjectSettingsForm({ project }: ProjectSettingsFormProps) {
           start_date: values.start_date || null,
           target_end_date: values.target_end_date || null,
           actual_end_date: values.actual_end_date || null,
-          budget_amount: values.budget_amount,
+          budget_amount: values.budget_amount != null ? Math.round(values.budget_amount * 100) : null,
           tags: values.tags || [],
           updated_by: user?.id,
           updated_at: new Date().toISOString(),
@@ -297,11 +297,11 @@ export function ProjectSettingsForm({ project }: ProjectSettingsFormProps) {
                 name="budget_amount"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Budget (in cents)</FormLabel>
+                    <FormLabel>Budget ($)</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
-                        placeholder="e.g., 100000 for $1,000"
+                        placeholder="e.g., 1000"
                         {...field}
                         value={field.value ?? ''}
                         onChange={(e) =>

--- a/src/lib/validators/project.ts
+++ b/src/lib/validators/project.ts
@@ -73,7 +73,7 @@ export const createProjectSchema = z.object({
   priority: projectPrioritySchema.default('medium'),
   start_date: z.string().optional().nullable(),
   target_end_date: z.string().optional().nullable(),
-  budget_amount: z.number().int().min(0).optional().nullable(),
+  budget_amount: z.number().min(0).optional().nullable(),
   tags: z.array(z.string()).optional().default([]),
 })
 
@@ -88,7 +88,7 @@ export const updateProjectSchema = z.object({
   start_date: z.string().optional().nullable(),
   target_end_date: z.string().optional().nullable(),
   actual_end_date: z.string().optional().nullable(),
-  budget_amount: z.number().int().min(0).optional().nullable(),
+  budget_amount: z.number().min(0).optional().nullable(),
   tags: z.array(z.string()).optional(),
 })
 


### PR DESCRIPTION
- Settings form now accepts dollar amounts and converts to cents for storage
- Overview tab formats budget as dollars with 2 decimal places
- Removed .int() constraint from budget validator to allow dollar input

https://claude.ai/code/session_014RsK63goXvADF4zVxxjt4T