### PR TITLE
fix(projects): resolve PGRST204 errors for progress/updated_by column…

### DIFF
--- a/src/components/projects/project-gantt-chart.tsx
+++ b/src/components/projects/project-gantt-chart.tsx
@@ -27,7 +27,7 @@ type ProjectTask = {
   start_date: string | null
   due_date: string | null
   completed_at: string | null
-  progress: number
+  progress?: number
   assignee?: {
     id: string
     email: string
@@ -317,7 +317,7 @@ export function ProjectGanttChart({
                         <div
                           className={`absolute inset-0 rounded-md ${getStatusColor(task.status)}`}
                           style={{
-                            width: `${task.status === 'done' ? 100 : task.progress}%`,
+                            width: `${task.status === 'done' ? 100 : (task.progress ?? 0)}%`,
                             opacity: 0.9,
                           }}
                         />

--- a/src/components/projects/project-tasks-list.tsx
+++ b/src/components/projects/project-tasks-list.tsx
@@ -69,7 +69,7 @@ type ProjectTask = {
   start_date: string | null
   due_date: string | null
   completed_at: string | null
-  progress: number
+  progress?: number
   sort_order: number
   parent_task_id: string | null
   created_by: string
@@ -219,11 +219,9 @@ export function ProjectTasksList({
 
       const update: Record<string, unknown> = {
         status: newStatus,
-        updated_by: user?.id,
       }
       if (newStatus === 'done') {
         update.completed_at = new Date().toISOString()
-        update.progress = 100
       }
 
       const { error } = await supabase

--- a/supabase/migrations/20260209220000_fix_project_tasks_schema_cache.sql
+++ b/supabase/migrations/20260209220000_fix_project_tasks_schema_cache.sql
@@ -1,0 +1,35 @@
+-- Migration: Fix project_tasks schema cache for progress and updated_by columns
+-- Description: Ensures progress and updated_by columns exist on project_tasks
+--   and refreshes PostgREST schema cache. The original migration
+--   (20260209200000) creates the table with these columns, but PostgREST may
+--   not have reloaded its schema cache after the DDL changes.
+-- Date: 2026-02-09
+
+-- Safety net: add columns if they don't exist (no-op if they already do)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'project_tasks'
+          AND column_name = 'progress'
+    ) THEN
+        ALTER TABLE public.project_tasks
+            ADD COLUMN progress INTEGER DEFAULT 0
+            CHECK (progress >= 0 AND progress <= 100);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'project_tasks'
+          AND column_name = 'updated_by'
+    ) THEN
+        ALTER TABLE public.project_tasks
+            ADD COLUMN updated_by UUID REFERENCES public.users(id);
+    END IF;
+END
+$$;
+
+-- Refresh PostgREST schema cache so it picks up the columns
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
…s on project_tasks

The project_tasks table migration did not include a PostgREST schema cache reload, causing PGRST204 errors when the frontend tried to update the progress and updated_by columns.

- Add migration to ensure columns exist and reload PostgREST schema cache
- Remove progress and updated_by from task status update to prevent errors (completed_at already tracks done state, updated_at trigger handles timestamp)
- Make progress optional in ProjectTask type and handle undefined in Gantt chart

https://claude.ai/code/session_01CJN71RMdyX4QsX6Rwcg8My