### PR TITLE
fix(projects): resolve JSX syntax error from badly merged code

### DIFF
--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -16,26 +16,17 @@ import {
   Settings,
   AlertTriangle,
   LayoutDashboard,
-  GanttChart,
-  FolderOpen,
-  Bell,
-  CheckCircle2,
 } from 'lucide-react'
-import dynamic from 'next/dynamic'
+import nextDynamic from 'next/dynamic'
 
-const ProjectOverview = dynamic(() => import('@/components/projects/workspace/project-overview').then(m => ({ default: m.ProjectOverview })), { ssr: false })
-const ProjectTasksBoard = dynamic(() => import('@/components/projects/workspace/project-tasks-board').then(m => ({ default: m.ProjectTasksBoard })), { ssr: false })
-const ProjectFilesManager = dynamic(() => import('@/components/projects/workspace/project-files-manager').then(m => ({ default: m.ProjectFilesManager })), { ssr: false })
-const ProjectActivityFeed = dynamic(() => import('@/components/projects/workspace/project-activity-feed').then(m => ({ default: m.ProjectActivityFeed })), { ssr: false })
-const ProjectCalendar = dynamic(() => import('@/components/projects/workspace/project-calendar').then(m => ({ default: m.ProjectCalendar })), { ssr: false })
+const ProjectOverview = nextDynamic(() => import('@/components/projects/workspace/project-overview').then(m => ({ default: m.ProjectOverview })), { ssr: false })
+const ProjectTasksBoard = nextDynamic(() => import('@/components/projects/workspace/project-tasks-board').then(m => ({ default: m.ProjectTasksBoard })), { ssr: false })
+const ProjectFilesManager = nextDynamic(() => import('@/components/projects/workspace/project-files-manager').then(m => ({ default: m.ProjectFilesManager })), { ssr: false })
+const ProjectActivityFeed = nextDynamic(() => import('@/components/projects/workspace/project-activity-feed').then(m => ({ default: m.ProjectActivityFeed })), { ssr: false })
+const ProjectCalendar = nextDynamic(() => import('@/components/projects/workspace/project-calendar').then(m => ({ default: m.ProjectCalendar })), { ssr: false })
 import { ProjectMembersPanel } from '@/components/projects/project-members-panel'
 import { ProjectOrganizationsPanel } from '@/components/projects/project-organizations-panel'
 import { ProjectSettingsForm } from '@/components/projects/project-settings-form'
-import { ProjectTasksList } from '@/components/projects/project-tasks-list'
-import { ProjectGanttChart } from '@/components/projects/project-gantt-chart'
-import { ProjectCalendarView } from '@/components/projects/project-calendar-view'
-import { ProjectComments } from '@/components/projects/project-comments'
-import { ProjectFiles } from '@/components/projects/project-files'
 import { ProjectCommunicationSettings } from '@/components/projects/project-communication-settings'
 
 function getStatusBadgeVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
@@ -236,51 +227,6 @@ export default async function ProjectWorkspacePage({
 
   const activeMembers = project.project_members?.filter((m: any) => m.is_active) ?? []
   const activeFiles = files.filter((f: any) => f.name !== '.folder')
-  // Fetch project tasks
-  let projectTasks: any[] = []
-  const { data: tasksData, error: tasksError } = await supabase
-    .from('project_tasks')
-    .select(`
-      *,
-      assignee:users!project_tasks_assigned_to_fkey(id, email, profiles:profiles(name, avatar_url))
-    `)
-    .eq('project_id', projectId)
-    .order('sort_order', { ascending: true })
-    .order('created_at', { ascending: false })
-
-  if (!tasksError) {
-    projectTasks = tasksData ?? []
-  }
-
-  // Fetch project comments
-  let projectComments: any[] = []
-  const { data: commentsData, error: commentsError } = await supabase
-    .from('project_comments')
-    .select(`
-      *,
-      author:users!project_comments_created_by_fkey(id, email, profiles:profiles(name, avatar_url))
-    `)
-    .eq('project_id', projectId)
-    .order('created_at', { ascending: true })
-
-  if (!commentsError) {
-    projectComments = commentsData ?? []
-  }
-
-  // Fetch project files
-  let projectFiles: any[] = []
-  const { data: filesData, error: filesError } = await supabase
-    .from('project_files')
-    .select(`
-      *,
-      uploader:users!project_files_uploaded_by_fkey(id, email, profiles:profiles(name, avatar_url))
-    `)
-    .eq('project_id', projectId)
-    .order('created_at', { ascending: false })
-
-  if (!filesError) {
-    projectFiles = filesData ?? []
-  }
 
   // Fetch communication settings
   let commSettings: any = null
@@ -293,21 +239,6 @@ export default async function ProjectWorkspacePage({
   if (!settingsError) {
     commSettings = settingsData
   }
-
-  const memberCount = project.project_members?.filter((m: any) => m.is_active).length ?? 0
-  const orgCount = project.project_organizations?.filter((o: any) => o.is_active).length ?? 0
-  const tasksDone = projectTasks.filter((t: any) => t.status === 'done').length
-  const tasksTotal = projectTasks.length
-
-  // Only active project members can be assigned to tasks
-  const taskAssignees = (project.project_members ?? [])
-    .filter((m: any) => m.is_active && m.user)
-    .map((m: any) => ({
-      id: m.user.id,
-      email: m.user.email,
-      role: m.user.role,
-      profiles: m.user.profiles,
-    }))
 
   return (
     <div className="space-y-6">
@@ -373,281 +304,6 @@ export default async function ProjectWorkspacePage({
               <span className="hidden sm:inline">Files</span>
               {activeFiles.length > 0 && (
                 <span className="text-xs bg-muted px-1.5 py-0.5 rounded-full">{activeFiles.length}</span>
-      {/* Quick Stats */}
-      <div className="grid gap-4 grid-cols-2 md:grid-cols-5">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Tasks</CardTitle>
-            <ListTodo className="h-4 w-4 text-slate-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{tasksTotal}</div>
-            <p className="text-xs text-slate-500">
-              {tasksDone} completed
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Team</CardTitle>
-            <Users className="h-4 w-4 text-slate-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{memberCount}</div>
-            <p className="text-xs text-slate-500">Active members</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Files</CardTitle>
-            <FolderOpen className="h-4 w-4 text-slate-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{projectFiles.length}</div>
-            <p className="text-xs text-slate-500">Uploaded</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Start Date</CardTitle>
-            <Calendar className="h-4 w-4 text-slate-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              {project.start_date
-                ? new Date(project.start_date).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                  })
-                : 'Not set'}
-            </div>
-            <p className="text-xs text-slate-500">
-              {project.start_date
-                ? new Date(project.start_date).getFullYear()
-                : 'Schedule pending'}
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Target End</CardTitle>
-            <Target className="h-4 w-4 text-slate-400" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">
-              {project.target_end_date
-                ? new Date(project.target_end_date).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                  })
-                : 'Not set'}
-            </div>
-            <p className="text-xs text-slate-500">
-              {project.target_end_date
-                ? new Date(project.target_end_date).getFullYear()
-                : 'No deadline'}
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Tabbed Content */}
-      <Tabs defaultValue="tasks" className="space-y-4">
-        <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
-          <TabsList className="inline-flex w-auto min-w-full md:min-w-0">
-            <TabsTrigger value="tasks" className="gap-2">
-              <ListTodo className="h-4 w-4" />
-              <span className="hidden sm:inline">Tasks</span>
-            </TabsTrigger>
-            <TabsTrigger value="gantt" className="gap-2">
-              <GanttChart className="h-4 w-4" />
-              <span className="hidden sm:inline">Gantt</span>
-            </TabsTrigger>
-            <TabsTrigger value="calendar" className="gap-2">
-              <Calendar className="h-4 w-4" />
-              <span className="hidden sm:inline">Calendar</span>
-            </TabsTrigger>
-            <TabsTrigger value="comments" className="gap-2">
-              <MessageSquare className="h-4 w-4" />
-              <span className="hidden sm:inline">Comments</span>
-              {projectComments.length > 0 && (
-                <span className="ml-1 rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium">
-                  {projectComments.length}
-                </span>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value="files" className="gap-2">
-              <FolderOpen className="h-4 w-4" />
-              <span className="hidden sm:inline">Files</span>
-              {projectFiles.length > 0 && (
-                <span className="ml-1 rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium">
-                  {projectFiles.length}
-                </span>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value="overview" className="gap-2">
-              <FolderKanban className="h-4 w-4" />
-              <span className="hidden sm:inline">Overview</span>
-            </TabsTrigger>
-            <TabsTrigger value="team" className="gap-2">
-              <Users className="h-4 w-4" />
-              <span className="hidden sm:inline">Team</span>
-            </TabsTrigger>
-            {canEdit && (
-              <TabsTrigger value="settings" className="gap-2">
-                <Settings className="h-4 w-4" />
-                <span className="hidden sm:inline">Settings</span>
-              </TabsTrigger>
-            )}
-          </TabsList>
-        </div>
-
-        {/* Tasks Tab */}
-        <TabsContent value="tasks">
-          <ProjectTasksList
-            projectId={project.id}
-            tasks={projectTasks}
-            members={taskAssignees}
-            canEdit={canEdit}
-          />
-        </TabsContent>
-
-        {/* Gantt Chart Tab */}
-        <TabsContent value="gantt">
-          <ProjectGanttChart
-            projectId={project.id}
-            tasks={projectTasks}
-            projectStartDate={project.start_date}
-            projectEndDate={project.target_end_date}
-          />
-        </TabsContent>
-
-        {/* Calendar Tab */}
-        <TabsContent value="calendar">
-          <ProjectCalendarView
-            projectId={project.id}
-            tasks={projectTasks}
-          />
-        </TabsContent>
-
-        {/* Comments Tab */}
-        <TabsContent value="comments">
-          <ProjectComments
-            projectId={project.id}
-            comments={projectComments}
-            currentUserId={user.id}
-            canEdit={canEdit}
-          />
-        </TabsContent>
-
-        {/* Files Tab */}
-        <TabsContent value="files">
-          <ProjectFiles
-            projectId={project.id}
-            files={projectFiles}
-            currentUserId={user.id}
-            canEdit={canEdit}
-          />
-        </TabsContent>
-
-        {/* Overview Tab */}
-        <TabsContent value="overview" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Project Details</CardTitle>
-              <CardDescription>Overview and description of this project</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {project.description && (
-                <div>
-                  <h4 className="text-sm font-medium text-slate-700 mb-2">Description</h4>
-                  <p className="text-slate-600 whitespace-pre-wrap">{project.description}</p>
-                </div>
-              )}
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-4">
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Status</span>
-                    <Badge variant={getStatusBadgeVariant(project.status)} className="capitalize">
-                      {project.status.replace('_', ' ')}
-                    </Badge>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Priority</span>
-                    <Badge
-                      variant="outline"
-                      className={`capitalize ${getPriorityBadgeClass(project.priority)}`}
-                    >
-                      {project.priority}
-                    </Badge>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Organization</span>
-                    <span className="font-medium">
-                      {project.organization?.name ?? 'N/A'}
-                    </span>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Created By</span>
-                    <span className="font-medium">
-                      {project.creator?.profiles?.name ?? project.creator?.email ?? 'Unknown'}
-                    </span>
-                  </div>
-                  <div className="flex justify-between py-2">
-                    <span className="text-slate-500">Created</span>
-                    <span>{new Date(project.created_at).toLocaleDateString()}</span>
-                  </div>
-                </div>
-                <div className="space-y-4">
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Start Date</span>
-                    <span>
-                      {project.start_date
-                        ? new Date(project.start_date).toLocaleDateString()
-                        : 'Not set'}
-                    </span>
-                  </div>
-                  <div className="flex justify-between py-2 border-b border-slate-100">
-                    <span className="text-slate-500">Target End Date</span>
-                    <span>
-                      {project.target_end_date
-                        ? new Date(project.target_end_date).toLocaleDateString()
-                        : 'Not set'}
-                    </span>
-                  </div>
-                  {project.actual_end_date && (
-                    <div className="flex justify-between py-2 border-b border-slate-100">
-                      <span className="text-slate-500">Actual End Date</span>
-                      <span>{new Date(project.actual_end_date).toLocaleDateString()}</span>
-                    </div>
-                  )}
-                  {project.budget_amount && (
-                    <div className="flex justify-between py-2 border-b border-slate-100">
-                      <span className="text-slate-500">Budget</span>
-                      <span className="font-medium">
-                        ${(project.budget_amount / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                      </span>
-                    </div>
-                  )}
-                  <div className="flex justify-between py-2">
-                    <span className="text-slate-500">Organizations</span>
-                    <span className="font-medium">{orgCount} assigned</span>
-                  </div>
-                </div>
-              </div>
-
-              {project.tags && project.tags.length > 0 && (
-                <div>
-                  <h4 className="text-sm font-medium text-slate-700 mb-2">Tags</h4>
-                  <div className="flex flex-wrap gap-2">
-                    {project.tags.map((tag: string, index: number) => (
-                      <Badge key={index} variant="secondary">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
               )}
             </TabsTrigger>
             <TabsTrigger


### PR DESCRIPTION
Two versions of the project workspace page were merged together, inserting old Quick Stats cards and a duplicate Tabs component in the middle of a TabsTrigger element. This caused a build-breaking JSX syntax error ("Expected '</', got '{'").

Changes:
- Remove duplicate code block (Quick Stats, second Tabs) spliced into the workspace Tabs component
- Remove duplicate data fetching (projectTasks, projectComments, projectFiles redeclared in same scope)
- Rename `import dynamic` from next/dynamic to `nextDynamic` to avoid collision with `export const dynamic = 'force-dynamic'`
- Remove unused imports (GanttChart, FolderOpen, Bell, CheckCircle2, ProjectTasksList, ProjectGanttChart, ProjectCalendarView, ProjectComments, ProjectFiles)

https://claude.ai/code/session_01Hs74i58qC5KisK4tQdnQyg