### PR TITLE
fix(navigation): Fix syntax error and duplicate const in sidebar

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -187,21 +187,18 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
     "/dashboard/projects/timeline",
     "/dashboard/projects/communication",
   ];
-  const supportClient = [
-    "/dashboard/tasks",
-    "/dashboard/tickets",
-    "/dashboard/services/current",
-    "/dashboard/services",
+
   // Base client navigation
   const servicesClient = [
     "/dashboard/service",
     "/dashboard/tickets",
+    "/dashboard/services/current",
   ];
   const projectsClient = [
     "/dashboard/projects",
-    "/dashboard/projects#tasks",
-    "/dashboard/projects#timeline",
-    "/dashboard/projects#communication",
+    "/dashboard/projects/tasks",
+    "/dashboard/projects/timeline",
+    "/dashboard/projects/communication",
   ];
   const filesClient = [
     "/dashboard/contracts",


### PR DESCRIPTION
Fixed critical build error in sidebar.tsx:
- Removed orphaned supportClient array declaration (merge conflict artifact)
- Fixed missing closing bracket that caused syntax error
- Updated projectsClient to use actual routes instead of hash fragments
- Ensured servicesClient includes /dashboard/services/current

This resolves the Vercel build failure:
Error: Expression expected at line 196 (duplicate const supportClient)

https://claude.ai/code/session_015DaCBDvAeHdn4EtsmmegED