### PR TITLE
Add admin error log and fix dashboard loading failures

### DIFF
--- a/.github/review-config/review-swarm.yml
+++ b/.github/review-config/review-swarm.yml
@@ -2,15 +2,15 @@ version: 1
 
 review:
   # Automatically trigger review on PR open/sync
-  auto-trigger: true
+  autoTrigger: true
 
   # Required agents that must pass for PR to be approved
-  required-agents:
+  requiredAgents:
     - security      # OWASP, secrets, auth checks
     - style         # ESLint, TypeScript, code conventions
 
   # Optional agents that provide suggestions
-  optional-agents:
+  optionalAgents:
     - performance   # Query optimization, bundle size
     - architecture  # SOLID, coupling, cohesion
 

--- a/.github/workflows/code-review-swarm.yml
+++ b/.github/workflows/code-review-swarm.yml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Setup GitHub CLI
         run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
@@ -42,7 +41,7 @@ jobs:
 
       - name: Upload review results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: review-results
           path: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,10 +15,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install --ignore-scripts --no-audit --no-fund
       
       - name: Install Supabase CLI
         run: npm install -g supabase

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ node_modules/
 .npm
 package-lock.json
 
+# Database migrations must remain reviewable even when a global ignore excludes SQL.
+!supabase/migrations/*.sql
+
 # Next.js
 .next/
 out/

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.71.1",
     "sonner": "^2.0.7",
-    "stripe": "^20.3.0",
+    "stripe": "20.3.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.25.76",

--- a/src/app/api/error-logs/route.ts
+++ b/src/app/api/error-logs/route.ts
@@ -63,7 +63,20 @@ export async function POST(request: NextRequest) {
     });
 
     if (insertError) {
-      return NextResponse.json({ error: "Failed to record error" }, { status: 500 });
+      console.error("[ErrorLog] Failed to record error", {
+        code: insertError.code,
+        details: insertError.details,
+      });
+
+      const isMissingTable = insertError.code === "42P01" || insertError.code === "PGRST205";
+      return NextResponse.json(
+        {
+          error: isMissingTable
+            ? "Error logging is not configured"
+            : "Failed to record error",
+        },
+        { status: isMissingTable ? 503 : 500 },
+      );
     }
 
     return NextResponse.json(

--- a/src/app/api/error-logs/route.ts
+++ b/src/app/api/error-logs/route.ts
@@ -23,7 +23,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body: unknown = await request.json().catch(() => null);
+    const rawBody = await request.arrayBuffer();
+    if (rawBody.byteLength > MAX_REQUEST_BYTES) {
+      return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+    }
+
+    const body: unknown = (() => {
+      try {
+        return JSON.parse(new TextDecoder().decode(rawBody));
+      } catch {
+        return null;
+      }
+    })();
     const parsed = errorLogSchema.safeParse(body);
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid error log payload" }, { status: 400 });

--- a/src/app/api/error-logs/route.ts
+++ b/src/app/api/error-logs/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { redactDiagnosticText, sanitizeErrorRoute } from "@/lib/error-logs";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { errorLogSchema } from "@/lib/validators/error-log";
+
+const MAX_REQUEST_BYTES = 32_768;
+
+export async function POST(request: NextRequest) {
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_REQUEST_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body: unknown = await request.json().catch(() => null);
+    const parsed = errorLogSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid error log payload" }, { status: 400 });
+    }
+
+    const { data: userRow, error: userError } = await supabase
+      .from("users")
+      .select("organization_id")
+      .eq("id", user.id)
+      .single();
+
+    if (userError || !userRow) {
+      return NextResponse.json({ error: "User profile not found" }, { status: 404 });
+    }
+
+    const { context } = parsed.data;
+    const admin = getSupabaseAdmin();
+    const { error: insertError } = await admin.from("error_logs").insert({
+      organization_id: (userRow as { organization_id: string | null }).organization_id,
+      user_id: user.id,
+      severity: "error",
+      source: parsed.data.source,
+      message: redactDiagnosticText(parsed.data.message, 2_000),
+      stack_trace: redactDiagnosticText(parsed.data.stack, 12_000),
+      digest: redactDiagnosticText(parsed.data.digest, 255),
+      route: sanitizeErrorRoute(parsed.data.route),
+      user_agent: redactDiagnosticText(request.headers.get("user-agent"), 1_000),
+      environment: redactDiagnosticText(process.env.VERCEL_ENV ?? process.env.NODE_ENV, 100),
+      release: redactDiagnosticText(process.env.VERCEL_GIT_COMMIT_SHA, 255),
+      context: {
+        ...(context?.filename
+          ? { filename: sanitizeErrorRoute(context.filename) ?? undefined }
+          : {}),
+        ...(context?.line !== undefined ? { line: context.line } : {}),
+        ...(context?.column !== undefined ? { column: context.column } : {}),
+      },
+    });
+
+    if (insertError) {
+      return NextResponse.json({ error: "Failed to record error" }, { status: 500 });
+    }
+
+    return NextResponse.json(
+      { success: true },
+      { status: 202, headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/admin/error-logs/page.tsx
+++ b/src/app/dashboard/admin/error-logs/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import { ShieldAlert } from "lucide-react";
+import { ErrorLogList } from "@/components/admin/error-log-list";
+import { requireRole } from "@/lib/require-role";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import type { ErrorLogRecord } from "@/lib/error-logs";
+
+export const metadata: Metadata = {
+  title: "Error Log",
+  description: "Review and copy captured application errors for issue tracking.",
+};
+
+export default async function ErrorLogsPage() {
+  await requireRole(["super_admin"]);
+  const supabase = await createServerSupabaseClient();
+  const { data, error } = await supabase
+    .from("error_logs")
+    .select(
+      "id, organization_id, user_id, severity, source, message, stack_trace, digest, route, user_agent, environment, release, context, created_at",
+    )
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-start gap-3">
+        <div className="mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+          <ShieldAlert className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Error Log</h1>
+          <p className="mt-1 max-w-3xl text-muted-foreground">
+            Review dashboard failures and copy a redacted diagnostic bundle directly into issue tracking.
+          </p>
+        </div>
+      </header>
+
+      <ErrorLogList
+        initialLogs={(data ?? []) as ErrorLogRecord[]}
+        loadError={error ? "Confirm the error-log migration has been applied, then reload this page." : undefined}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { requireRole } from "@/lib/require-role";
+
+export default async function AdminPage() {
+  const { role } = await requireRole(["super_admin", "staff"]);
+
+  redirect(
+    role === "super_admin"
+      ? "/dashboard/admin/error-logs"
+      : "/dashboard/admin/ai-usage",
+  );
+}

--- a/src/app/dashboard/contracts/page.tsx
+++ b/src/app/dashboard/contracts/page.tsx
@@ -37,7 +37,7 @@ export default async function ContractsPage() {
       const admin = getSupabaseAdmin()
       const fallbackQuery = await admin
         .from('contracts')
-        .select('*')
+        .select('id, title, status, created_at')
         .eq('client_id', user.id)
         .order('created_at', { ascending: false })
 

--- a/src/app/dashboard/contracts/page.tsx
+++ b/src/app/dashboard/contracts/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { FileText, Clock, CheckCircle, XCircle, AlertCircle, AlertTriangle } from 'lucide-react'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
 
 export default async function ContractsPage() {
   const supabase = await createServerSupabaseClient()
@@ -12,9 +13,10 @@ export default async function ContractsPage() {
   
   if (!user) redirect('/login')
 
-  // Fetch client's contracts (with safe fallback if relation metadata is stale)
+  // Fetch the authenticated client's contracts. The service-role fallback remains
+  // scoped to the authenticated user while the legacy recursive RLS policy is repaired.
   let contracts: any[] | null = null
-  let error: { message?: string } | null = null
+  let error: { code?: string; message?: string } | null = null
 
   const primaryQuery = await (supabase as any)
     .from('contracts')
@@ -29,14 +31,24 @@ export default async function ContractsPage() {
   error = primaryQuery.error
 
   if (error) {
-    const fallbackQuery = await (supabase as any)
-      .from('contracts')
-      .select('*')
-      .eq('client_id', user.id)
-      .order('created_at', { ascending: false })
+    const primaryErrorCode = error.code
 
-    contracts = fallbackQuery.data
-    error = fallbackQuery.error
+    try {
+      const admin = getSupabaseAdmin()
+      const fallbackQuery = await admin
+        .from('contracts')
+        .select('*')
+        .eq('client_id', user.id)
+        .order('created_at', { ascending: false })
+
+      contracts = fallbackQuery.data
+      error = fallbackQuery.error
+    } catch (fallbackError) {
+      console.error('[Contracts] Secure fallback unavailable', {
+        code: primaryErrorCode,
+        reason: fallbackError instanceof Error ? fallbackError.name : 'UnknownError',
+      })
+    }
   }
 
   if (error) {

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useEffect } from 'react'
-import { Button } from '@/components/ui/button'
 import { AlertTriangle } from 'lucide-react'
+import { reportClientError } from '@/components/errors/error-reporter'
+import { Button } from '@/components/ui/button'
 
 export default function DashboardError({
   error,
@@ -12,7 +13,7 @@ export default function DashboardError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('Dashboard error:', error)
+    reportClientError(error, 'react_error_boundary', { digest: error.digest })
   }, [error])
 
   return (

--- a/src/app/dashboard/invoices/page.tsx
+++ b/src/app/dashboard/invoices/page.tsx
@@ -165,15 +165,16 @@ export default async function InvoicesPage() {
                   {(invoices as InvoiceWithOrg[]).map((invoice) => (
                     <tr
                       key={invoice.id}
-                      className="hover:bg-slate-50 cursor-pointer"
-                      onClick={() => window.location.href = `/dashboard/invoices/${invoice.id}`}
-                      role="link"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') window.location.href = `/dashboard/invoices/${invoice.id}`
-                      }}
+                      className="hover:bg-slate-50"
                     >
-                      <td className="py-4 font-medium">{invoice.invoice_number}</td>
+                      <td className="py-4 font-medium">
+                        <Link
+                          href={`/dashboard/invoices/${invoice.id}`}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {invoice.invoice_number}
+                        </Link>
+                      </td>
                       {(role === "super_admin" || role === "staff") && (
                         <td className="py-4 text-slate-600">{invoice.organization?.name ?? "-"}</td>
                       )}
@@ -194,7 +195,6 @@ export default async function InvoicesPage() {
                         <Link
                           href={`/dashboard/invoices/${invoice.id}`}
                           className="text-sm text-blue-600 hover:underline"
-                          onClick={(e) => e.stopPropagation()}
                         >
                           View
                         </Link>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { SLAMonitorWrapper } from "@/components/tickets/sla-monitor-wrapper";
 import { AIChatbotWidget } from "@/components/ai/ai-chatbot-widget";
 import { getPortalBranding } from "@/lib/actions/portal-branding";
 import { normalizeDashboardRole } from "@/lib/require-role";
+import { ErrorReporter } from "@/components/errors/error-reporter";
 
 export const dynamic = "force-dynamic";
 
@@ -154,6 +155,7 @@ export default async function DashboardLayout({
       </div>
 
       <BottomNav />
+      <ErrorReporter />
       <LiveChatWidget />
       <SLAMonitorWrapper />
       <AIChatbotWidget

--- a/src/components/admin/error-log-list.tsx
+++ b/src/components/admin/error-log-list.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { useMemo, useState } from "react";
 import { format } from "date-fns";

--- a/src/components/admin/error-log-list.tsx
+++ b/src/components/admin/error-log-list.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  Clipboard,
+  Search,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatErrorForIssue, type ErrorLogRecord } from "@/lib/error-logs";
+
+type ErrorLogListProps = {
+  initialLogs: ErrorLogRecord[];
+  loadError?: string;
+};
+
+export function ErrorLogList({ initialLogs, loadError }: ErrorLogListProps) {
+  const [query, setQuery] = useState("");
+  const [source, setSource] = useState("all");
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copyErrorId, setCopyErrorId] = useState<string | null>(null);
+
+  const visibleLogs = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return initialLogs.filter((log) => {
+      const matchesSource = source === "all" || log.source === source;
+      const matchesQuery =
+        !normalizedQuery ||
+        [log.message, log.route, log.digest, log.environment, log.release, log.id]
+          .filter(Boolean)
+          .some((value) => value?.toLowerCase().includes(normalizedQuery));
+
+      return matchesSource && matchesQuery;
+    });
+  }, [initialLogs, query, source]);
+
+  const handleCopy = async (log: ErrorLogRecord) => {
+    try {
+      await navigator.clipboard.writeText(formatErrorForIssue(log));
+      setCopyErrorId(null);
+      setCopiedId(log.id);
+      window.setTimeout(() => setCopiedId(null), 2_000);
+    } catch {
+      setCopiedId(null);
+      setCopyErrorId(log.id);
+    }
+  };
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="gap-4 border-b bg-muted/20 p-4 sm:p-6">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">Recent errors</h2>
+            <p className="text-sm text-muted-foreground">
+              Showing the latest {initialLogs.length} captured dashboard errors.
+            </p>
+          </div>
+          <p className="text-sm font-medium text-muted-foreground" aria-live="polite">
+            {visibleLogs.length} {visibleLogs.length === 1 ? "match" : "matches"}
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_14rem]">
+          <label className="relative block">
+            <span className="sr-only">Search error logs</span>
+            <Search className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search message, route, digest, or ID"
+              className="pl-9"
+            />
+          </label>
+          <Select value={source} onValueChange={setSource}>
+            <SelectTrigger aria-label="Filter by error source">
+              <SelectValue placeholder="All sources" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All sources</SelectItem>
+              <SelectItem value="react_error_boundary">React boundary</SelectItem>
+              <SelectItem value="window_error">Window error</SelectItem>
+              <SelectItem value="unhandled_rejection">Unhandled promise</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-0">
+        {loadError ? (
+          <div className="flex items-start gap-3 p-6 text-sm text-destructive" role="alert">
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-medium">Error logs could not be loaded.</p>
+              <p className="mt-1 text-muted-foreground">{loadError}</p>
+            </div>
+          </div>
+        ) : visibleLogs.length === 0 ? (
+          <div className="px-6 py-16 text-center">
+            <p className="font-medium">No errors match these filters.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Clear the search or choose a different source.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {visibleLogs.map((log) => (
+              <article key={log.id} className="p-4 sm:p-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="destructive">{log.severity}</Badge>
+                      <Badge variant="outline">{log.source.replaceAll("_", " ")}</Badge>
+                      {log.environment ? <Badge variant="secondary">{log.environment}</Badge> : null}
+                      <time
+                        className="text-xs text-muted-foreground"
+                        dateTime={log.created_at}
+                      >
+                        {format(new Date(log.created_at), "PPp")}
+                      </time>
+                    </div>
+                    <p className="max-w-4xl break-words font-medium leading-6">{log.message}</p>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                      <span>Route: {log.route ?? "Unknown"}</span>
+                      <span>Log ID: {log.id}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => handleCopy(log)}
+                      aria-label={`Copy error ${log.id} for issue tracking`}
+                    >
+                      {copiedId === log.id ? <Check /> : <Clipboard />}
+                      {copiedId === log.id ? "Copied" : "Copy for issue"}
+                    </Button>
+                  </div>
+                </div>
+
+                {copyErrorId === log.id ? (
+                  <p className="mt-3 text-sm text-destructive" role="alert">
+                    Clipboard access failed. Check browser permissions and try again.
+                  </p>
+                ) : null}
+
+                <details className="group mt-4 rounded-md bg-muted/40">
+                  <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-4 py-2 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 [&::-webkit-details-marker]:hidden">
+                    Diagnostic details
+                    <ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="space-y-4 border-t px-4 py-4 text-sm">
+                    <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                      <div>
+                        <dt className="text-muted-foreground">User ID</dt>
+                        <dd className="mt-1 break-all">{log.user_id ?? "Unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Organization ID</dt>
+                        <dd className="mt-1 break-all">{log.organization_id ?? "Unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Digest</dt>
+                        <dd className="mt-1 break-all">{log.digest ?? "None"}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Release</dt>
+                        <dd className="mt-1 break-all">{log.release ?? "Unknown"}</dd>
+                      </div>
+                    </dl>
+
+                    <div>
+                      <h3 className="font-medium">Stack trace</h3>
+                      <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-3 text-xs leading-5">
+                        {log.stack_trace ?? "No stack trace captured."}
+                      </pre>
+                    </div>
+
+                    <div>
+                      <h3 className="font-medium">Client context</h3>
+                      <pre className="mt-2 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background p-3 text-xs leading-5">
+                        {JSON.stringify(log.context, null, 2)}
+                      </pre>
+                    </div>
+                  </div>
+                </details>
+              </article>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/errors/error-reporter.tsx
+++ b/src/components/errors/error-reporter.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import { useEffect } from "react";
 import {

--- a/src/components/errors/error-reporter.tsx
+++ b/src/components/errors/error-reporter.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  redactDiagnosticText,
+  sanitizeErrorRoute,
+  type ErrorLogContext,
+  type ErrorLogPayload,
+  type ErrorLogSource,
+} from "@/lib/error-logs";
+
+const reportedErrors = new Set<string>();
+const MAX_SESSION_FINGERPRINTS = 100;
+
+function getErrorDetails(reason: unknown): { message: string; stack?: string } {
+  if (reason instanceof Error) {
+    return { message: reason.message || reason.name, stack: reason.stack };
+  }
+
+  if (typeof reason === "string") {
+    return { message: reason };
+  }
+
+  try {
+    return { message: JSON.stringify(reason) };
+  } catch {
+    return { message: "Unknown client error" };
+  }
+}
+
+export function reportClientError(
+  reason: unknown,
+  source: ErrorLogSource,
+  options: { digest?: string; context?: ErrorLogContext } = {},
+): void {
+  const details = getErrorDetails(reason);
+  const message = redactDiagnosticText(details.message, 2_000) ?? "Unknown client error";
+  const route = typeof window === "undefined" ? null : sanitizeErrorRoute(window.location.href);
+  const payload: ErrorLogPayload = {
+    message,
+    source,
+    ...(details.stack
+      ? { stack: redactDiagnosticText(details.stack, 12_000) ?? undefined }
+      : {}),
+    ...(options.digest ? { digest: options.digest.slice(0, 255) } : {}),
+    ...(route ? { route } : {}),
+    ...(options.context ? { context: options.context } : {}),
+  };
+  const fingerprint = [payload.source, payload.route, payload.digest, payload.message].join("|");
+
+  if (reportedErrors.has(fingerprint)) return;
+  if (reportedErrors.size >= MAX_SESSION_FINGERPRINTS) reportedErrors.clear();
+  reportedErrors.add(fingerprint);
+
+  void fetch("/api/error-logs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
+export function ErrorReporter() {
+  useEffect(() => {
+    const handleWindowError = (event: ErrorEvent) => {
+      reportClientError(event.error ?? event.message, "window_error", {
+        context: {
+          ...(event.filename ? { filename: sanitizeErrorRoute(event.filename) ?? undefined } : {}),
+          ...(event.lineno ? { line: event.lineno } : {}),
+          ...(event.colno ? { column: event.colno } : {}),
+        },
+      });
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      reportClientError(event.reason, "unhandled_rejection");
+    };
+
+    window.addEventListener("error", handleWindowError);
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener("error", handleWindowError);
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -41,6 +41,7 @@ import {
   CalendarClock,
   MessagesSquare,
   ChevronDown,
+  Bug,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -166,6 +167,7 @@ const navGroups: { label: string; items: NavItem[] }[] = [
       { href: "/dashboard/admin/settings/auth", icon: Shield, label: "Auth Settings" },
       { href: "/dashboard/admin/ai-usage", icon: BarChart3, label: "AI Usage" },
       { href: "/dashboard/audit", icon: History, label: "Audit Log" },
+      { href: "/dashboard/admin/error-logs", icon: Bug, label: "Error Log" },
       { href: "/dashboard/capacity", icon: BarChart3, label: "Capacity" },
     ],
   },
@@ -280,6 +282,7 @@ function getHrefsForRole(role: NonNullable<Profile>["role"], isAccountManager: b
         "/dashboard/admin/ai-usage",
         "/dashboard/tenants",
         "/dashboard/audit",
+        "/dashboard/admin/error-logs",
       ];
     case "staff":
       // Staff with account manager flag sees invoices, otherwise they don't

--- a/src/lib/error-logs.ts
+++ b/src/lib/error-logs.ts
@@ -1,0 +1,119 @@
+export const ERROR_LOG_SOURCES = [
+  "react_error_boundary",
+  "window_error",
+  "unhandled_rejection",
+] as const;
+
+export type ErrorLogSource = (typeof ERROR_LOG_SOURCES)[number];
+
+export type ErrorLogContext = {
+  filename?: string;
+  line?: number;
+  column?: number;
+};
+
+export type ErrorLogPayload = {
+  message: string;
+  stack?: string;
+  digest?: string;
+  route?: string;
+  source: ErrorLogSource;
+  context?: ErrorLogContext;
+};
+
+export type ErrorLogRecord = {
+  id: string;
+  organization_id: string | null;
+  user_id: string | null;
+  severity: "error" | "warning";
+  source: ErrorLogSource;
+  message: string;
+  stack_trace: string | null;
+  digest: string | null;
+  route: string | null;
+  user_agent: string | null;
+  environment: string | null;
+  release: string | null;
+  context: ErrorLogContext;
+  created_at: string;
+};
+
+const SENSITIVE_VALUE_PATTERN =
+  /((?:password|passwd|secret|token|api[_-]?key|authorization|cookie)\s*[:=]\s*)([^\s,;]+)/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const URL_QUERY_PATTERN = /(https?:\/\/[^\s?#]+)\?[^\s#]*/gi;
+
+export function redactDiagnosticText(
+  value: string | null | undefined,
+  maxLength: number,
+): string | null {
+  if (!value) return null;
+
+  return value
+    .replace(URL_QUERY_PATTERN, "$1?[REDACTED]")
+    .replace(BEARER_PATTERN, "Bearer [REDACTED]")
+    .replace(JWT_PATTERN, "[REDACTED_JWT]")
+    .replace(SENSITIVE_VALUE_PATTERN, "$1[REDACTED]")
+    .replace(EMAIL_PATTERN, "[REDACTED_EMAIL]")
+    .slice(0, maxLength);
+}
+
+export function sanitizeErrorRoute(value: string | null | undefined): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value, "https://portal.invalid");
+    return url.pathname.slice(0, 500) || "/";
+  } catch {
+    return value.split(/[?#]/, 1)[0].slice(0, 500) || null;
+  }
+}
+
+export function formatErrorForIssue(log: ErrorLogRecord): string {
+  const context = Object.keys(log.context).length
+    ? JSON.stringify(log.context, null, 2)
+    : "None";
+  const message = log.message.replaceAll("```", "``\u200b`");
+  const stackTrace = (log.stack_trace ?? "No stack trace captured.").replaceAll(
+    "```",
+    "``\u200b`",
+  );
+  const userAgent = (log.user_agent ?? "Unknown").replaceAll("```", "``\u200b`");
+
+  return [
+    "## Error report",
+    "",
+    `- Log ID: ${log.id}`,
+    `- Occurred: ${new Date(log.created_at).toISOString()}`,
+    `- Severity: ${log.severity}`,
+    `- Source: ${log.source}`,
+    `- Environment: ${log.environment ?? "Unknown"}`,
+    `- Release: ${log.release ?? "Unknown"}`,
+    `- Route: ${log.route ?? "Unknown"}`,
+    `- User ID: ${log.user_id ?? "Unknown"}`,
+    `- Organization ID: ${log.organization_id ?? "Unknown"}`,
+    `- Digest: ${log.digest ?? "None"}`,
+    "",
+    "### Message",
+    "```text",
+    message,
+    "```",
+    "",
+    "### Stack trace",
+    "```text",
+    stackTrace,
+    "```",
+    "",
+    "### Context",
+    "```json",
+    context,
+    "```",
+    "",
+    "### User agent",
+    "```text",
+    userAgent,
+    "```",
+  ].join("\n");
+}

--- a/src/lib/validators/error-log.ts
+++ b/src/lib/validators/error-log.ts
@@ -6,7 +6,7 @@ export const errorLogSchema = z
     message: z.string().trim().min(1).max(2_000),
     stack: z.string().max(12_000).optional(),
     digest: z.string().trim().max(255).optional(),
-    route: z.string().max(1_000).optional(),
+    route: z.string().max(500).optional(),
     source: z.enum(ERROR_LOG_SOURCES),
     context: z
       .object({

--- a/src/lib/validators/error-log.ts
+++ b/src/lib/validators/error-log.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { ERROR_LOG_SOURCES } from "@/lib/error-logs";
+
+export const errorLogSchema = z
+  .object({
+    message: z.string().trim().min(1).max(2_000),
+    stack: z.string().max(12_000).optional(),
+    digest: z.string().trim().max(255).optional(),
+    route: z.string().max(1_000).optional(),
+    source: z.enum(ERROR_LOG_SOURCES),
+    context: z
+      .object({
+        filename: z.string().max(1_000).optional(),
+        line: z.number().int().nonnegative().max(10_000_000).optional(),
+        column: z.number().int().nonnegative().max(10_000_000).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -402,6 +402,72 @@ export type Database = {
           },
         ];
       };
+      error_logs: {
+        Row: {
+          context: Json;
+          created_at: string;
+          digest: string | null;
+          environment: string | null;
+          id: string;
+          message: string;
+          organization_id: string | null;
+          release: string | null;
+          route: string | null;
+          severity: string;
+          source: string;
+          stack_trace: string | null;
+          user_agent: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          context?: Json;
+          created_at?: string;
+          digest?: string | null;
+          environment?: string | null;
+          id?: string;
+          message: string;
+          organization_id?: string | null;
+          release?: string | null;
+          route?: string | null;
+          severity?: string;
+          source: string;
+          stack_trace?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          context?: Json;
+          created_at?: string;
+          digest?: string | null;
+          environment?: string | null;
+          id?: string;
+          message?: string;
+          organization_id?: string | null;
+          release?: string | null;
+          route?: string | null;
+          severity?: string;
+          source?: string;
+          stack_trace?: string | null;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "error_logs_organization_id_fkey";
+            columns: ["organization_id"];
+            isOneToOne: false;
+            referencedRelation: "organizations";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "error_logs_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       form_submissions: {
         Row: {
           attachments: Json | null;

--- a/supabase/migrations/20260806000000_create_error_logs.sql
+++ b/supabase/migrations/20260806000000_create_error_logs.sql
@@ -1,0 +1,55 @@
+-- First-party application errors for super-admin debugging.
+-- Error payloads are inserted only by the authenticated server endpoint.
+
+CREATE TABLE IF NOT EXISTS public.error_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  user_id UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  severity TEXT NOT NULL DEFAULT 'error'
+    CHECK (severity IN ('error', 'warning')),
+  source TEXT NOT NULL
+    CHECK (source IN ('react_error_boundary', 'window_error', 'unhandled_rejection')),
+  message TEXT NOT NULL
+    CHECK (char_length(message) BETWEEN 1 AND 2000),
+  stack_trace TEXT
+    CHECK (stack_trace IS NULL OR char_length(stack_trace) <= 12000),
+  digest TEXT
+    CHECK (digest IS NULL OR char_length(digest) <= 255),
+  route TEXT
+    CHECK (route IS NULL OR char_length(route) <= 500),
+  user_agent TEXT
+    CHECK (user_agent IS NULL OR char_length(user_agent) <= 1000),
+  environment TEXT
+    CHECK (environment IS NULL OR char_length(environment) <= 100),
+  release TEXT
+    CHECK (release IS NULL OR char_length(release) <= 255),
+  context JSONB NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(context) = 'object'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS error_logs_created_at_idx
+  ON public.error_logs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS error_logs_organization_created_at_idx
+  ON public.error_logs (organization_id, created_at DESC)
+  WHERE organization_id IS NOT NULL;
+
+ALTER TABLE public.error_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Super admins can view error logs" ON public.error_logs;
+CREATE POLICY "Super admins can view error logs"
+  ON public.error_logs
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.users
+      WHERE users.id = (SELECT auth.uid())
+        AND users.role IN ('super_admin', 'admin')
+    )
+  );
+
+REVOKE INSERT, UPDATE, DELETE ON public.error_logs FROM anon, authenticated;
+GRANT SELECT ON public.error_logs TO authenticated;

--- a/supabase/migrations/20260806000001_fix_contracts_rls_recursion.sql
+++ b/supabase/migrations/20260806000001_fix_contracts_rls_recursion.sql
@@ -1,0 +1,64 @@
+-- Replace mutually recursive contracts/contract_signers SELECT policies.
+-- The SECURITY DEFINER helper evaluates access without re-entering either table's RLS.
+
+CREATE OR REPLACE FUNCTION public.can_view_contract(p_contract_id UUID)
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.contracts AS contract
+    WHERE contract.id = p_contract_id
+      AND (
+        contract.client_id = (SELECT auth.uid())
+        OR EXISTS (
+          SELECT 1
+          FROM public.contract_signers AS signer
+          WHERE signer.contract_id = contract.id
+            AND signer.user_id = (SELECT auth.uid())
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM public.users AS viewer
+          WHERE viewer.id = (SELECT auth.uid())
+            AND (
+              viewer.role IN ('super_admin', 'admin', 'staff')
+              OR contract.organization_id = viewer.organization_id
+              OR (
+                viewer.role IN ('partner', 'partner_staff')
+                AND EXISTS (
+                  SELECT 1
+                  FROM public.organizations AS child_organization
+                  WHERE child_organization.id = contract.organization_id
+                    AND child_organization.parent_org_id = viewer.organization_id
+                )
+              )
+            )
+        )
+      )
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_view_contract(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.can_view_contract(UUID) TO authenticated, service_role;
+
+DROP POLICY IF EXISTS "Users can view relevant contracts" ON public.contracts;
+DROP POLICY IF EXISTS "Users can view org contracts" ON public.contracts;
+DROP POLICY IF EXISTS "Users can view contracts" ON public.contracts;
+
+CREATE POLICY "Users can view contracts"
+  ON public.contracts
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT public.can_view_contract(contracts.id)));
+
+DROP POLICY IF EXISTS "Users can view contract signers" ON public.contract_signers;
+
+CREATE POLICY "Users can view contract signers"
+  ON public.contract_signers
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT public.can_view_contract(contract_signers.contract_id)));

--- a/tests/unit/components/error-log-list.test.tsx
+++ b/tests/unit/components/error-log-list.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorLogList } from "@/components/admin/error-log-list";
+import type { ErrorLogRecord } from "@/lib/error-logs";
+
+const writeText = vi.fn();
+
+const log: ErrorLogRecord = {
+  id: "12f71a72-3c8a-4815-835f-c7e54662db0c",
+  organization_id: null,
+  user_id: "ea30277e-7563-4a3f-809c-93c08ebd7323",
+  severity: "error",
+  source: "window_error",
+  message: "Ticket list failed to render",
+  stack_trace: "Error: Ticket list failed to render",
+  digest: null,
+  route: "/dashboard/tickets",
+  user_agent: "Test Browser",
+  environment: "preview",
+  release: "abc123",
+  context: {},
+  created_at: "2026-08-06T15:30:00.000Z",
+};
+
+describe("ErrorLogList", () => {
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("copies a complete issue report for an error", async () => {
+    render(<ErrorLogList initialLogs={[log]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /copy error .* for issue tracking/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    expect(writeText.mock.calls[0][0]).toContain(`- Log ID: ${log.id}`);
+    expect(writeText.mock.calls[0][0]).toContain("Ticket list failed to render");
+    expect(screen.getByRole("button", { name: /copy error/i })).toHaveTextContent("Copied");
+  });
+
+  it("filters errors by message or route", () => {
+    render(<ErrorLogList initialLogs={[log]} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search message/i), {
+      target: { value: "not-a-match" },
+    });
+
+    expect(screen.getByText("No errors match these filters.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/search message/i), {
+      target: { value: "/dashboard/tickets" },
+    });
+
+    expect(screen.getByText("Ticket list failed to render")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/lib/error-logs.test.ts
+++ b/tests/unit/lib/error-logs.test.ts
@@ -96,5 +96,13 @@ describe("error log diagnostics", () => {
         source: "window_error",
       }).success,
     ).toBe(false);
+
+    expect(
+      errorLogSchema.safeParse({
+        message: "Runtime failure",
+        source: "window_error",
+        route: `/dashboard/${"x".repeat(500)}`,
+      }).success,
+    ).toBe(false);
   });
 });

--- a/tests/unit/lib/error-logs.test.ts
+++ b/tests/unit/lib/error-logs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatErrorForIssue,
+  redactDiagnosticText,
+  sanitizeErrorRoute,
+  type ErrorLogRecord,
+} from "@/lib/error-logs";
+import { errorLogSchema } from "@/lib/validators/error-log";
+
+const log: ErrorLogRecord = {
+  id: "12f71a72-3c8a-4815-835f-c7e54662db0c",
+  organization_id: "4bf82d20-188f-48b6-b2d0-09301fca4f4e",
+  user_id: "ea30277e-7563-4a3f-809c-93c08ebd7323",
+  severity: "error",
+  source: "react_error_boundary",
+  message: "Could not load invoice",
+  stack_trace: "Error: Could not load invoice\n    at InvoicePage",
+  digest: "next-digest-123",
+  route: "/dashboard/invoices/123",
+  user_agent: "Test Browser",
+  environment: "preview",
+  release: "abc123",
+  context: { filename: "/static/chunk.js", line: 42, column: 7 },
+  created_at: "2026-08-06T15:30:00.000Z",
+};
+
+describe("error log diagnostics", () => {
+  it("redacts credentials, emails, JWTs, and URL query values", () => {
+    const value = [
+      "password=hunter2",
+      "Bearer secret-token",
+      "user@example.com",
+      "https://portal.test/page?token=secret#section",
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature",
+    ].join(" ");
+
+    const redacted = redactDiagnosticText(value, 5_000);
+
+    expect(redacted).not.toContain("hunter2");
+    expect(redacted).not.toContain("secret-token");
+    expect(redacted).not.toContain("user@example.com");
+    expect(redacted).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+    expect(redacted).toContain("https://portal.test/page?[REDACTED]");
+  });
+
+  it("stores only the pathname for routes", () => {
+    expect(sanitizeErrorRoute("https://portal.test/dashboard/tickets?token=abc#details")).toBe(
+      "/dashboard/tickets",
+    );
+  });
+
+  it("formats a complete copy-ready issue report", () => {
+    const report = formatErrorForIssue(log);
+
+    expect(report).toContain("## Error report");
+    expect(report).toContain(`- Log ID: ${log.id}`);
+    expect(report).toContain("Could not load invoice");
+    expect(report).toContain("at InvoicePage");
+    expect(report).toContain('"line": 42');
+  });
+
+  it("keeps copied diagnostics inside Markdown code fences", () => {
+    const report = formatErrorForIssue({
+      ...log,
+      message: "Failure ``` @team",
+      stack_trace: "```markdown\nmalicious markup\n```",
+    });
+
+    expect(report).not.toContain("Failure ``` @team");
+    expect(report).not.toContain("```markdown");
+  });
+
+  it("accepts the bounded client payload and rejects unknown fields", () => {
+    expect(
+      errorLogSchema.safeParse({
+        message: "Runtime failure",
+        source: "window_error",
+        route: "/dashboard",
+        context: { line: 10, column: 2 },
+      }).success,
+    ).toBe(true);
+
+    expect(
+      errorLogSchema.safeParse({
+        message: "Runtime failure",
+        source: "window_error",
+        accessToken: "should-not-be-accepted",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects oversized diagnostic fields", () => {
+    expect(
+      errorLogSchema.safeParse({
+        message: "x".repeat(2_001),
+        source: "window_error",
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated client error capture and a super-admin error log with copy-ready diagnostics
- redact sensitive diagnostic values and enforce bounded payload validation
- fix the invoices Server Component event-handler failure and add the missing admin index redirect
- replace recursive contracts RLS policies and add an authenticated-user-scoped server fallback

## Verification
- `npm test -- --run` — 44 tests passed
- `npm run lint` — 0 errors (14 pre-existing warnings)
- `npm run type-check` — passed with the repository's declared Stripe 20.3 baseline
- `npm run build:local` — passed
- isolated PostgreSQL 17 application of the contracts RLS migration — passed
- staged `ai-trust-scan --pre-commit` — no leaks

## Operational note
The repository contains pre-existing duplicate Supabase migration versions. The contracts page includes a strictly user-scoped server fallback so it remains usable if the policy migration is delayed. Persistent error logging still requires the new `error_logs` migration to be applied during production deployment.