### PR TITLE
Fix Supabase SSL for recovery migrations

### DIFF
--- a/scripts/apply-recovery-migrations.ts
+++ b/scripts/apply-recovery-migrations.ts
@@ -3,6 +3,7 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { Client } from 'pg'
+import { normalizeSupabaseSslConnection } from './lib/postgres-connection'
 
 const RECOVERY_MIGRATIONS = [
   '20260806000000_create_error_logs.sql',
@@ -15,7 +16,7 @@ function getConnectionString(): string {
     process.env.POSTGRES_PRISMA_URL ||
     process.env.POSTGRES_URL
 
-  if (configuredUrl) return configuredUrl
+  if (configuredUrl) return normalizeSupabaseSslConnection(configuredUrl)
 
   const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
   const projectRef =
@@ -29,7 +30,9 @@ function getConnectionString(): string {
     )
   }
 
-  return `postgresql://postgres:${encodeURIComponent(password)}@db.${projectRef}.supabase.co:5432/postgres?sslmode=require`
+  return normalizeSupabaseSslConnection(
+    `postgresql://postgres:${encodeURIComponent(password)}@db.${projectRef}.supabase.co:5432/postgres`,
+  )
 }
 
 async function applyRecoveryMigrations() {

--- a/scripts/lib/postgres-connection.ts
+++ b/scripts/lib/postgres-connection.ts
@@ -1,0 +1,27 @@
+export function normalizeSupabaseSslConnection(connectionString: string): string {
+  let url: URL
+
+  try {
+    url = new URL(connectionString)
+  } catch {
+    throw new Error('The configured Postgres connection URL is invalid')
+  }
+
+  if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+    throw new Error('The configured database URL must use the Postgres protocol')
+  }
+
+  const hostname = url.hostname.toLowerCase()
+  const isSupabaseHost =
+    hostname.endsWith('.supabase.co') || hostname.endsWith('.supabase.com')
+
+  if (!isSupabaseHost) return connectionString
+
+  // Supabase connection endpoints can present a self-signed certificate chain.
+  // Use libpq's `require` semantics (encrypted without CA verification) only for
+  // Supabase-owned hosts; all other Postgres URLs retain their configured mode.
+  url.searchParams.set('uselibpqcompat', 'true')
+  url.searchParams.set('sslmode', 'require')
+
+  return url.toString()
+}

--- a/tests/unit/lib/postgres-connection.test.ts
+++ b/tests/unit/lib/postgres-connection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSupabaseSslConnection } from '../../../scripts/lib/postgres-connection'
+
+describe('normalizeSupabaseSslConnection', () => {
+  it('uses encrypted libpq compatibility mode for Supabase direct connections', () => {
+    const result = normalizeSupabaseSslConnection(
+      'postgresql://user:password@db.project-ref.supabase.co:5432/postgres?sslmode=verify-full',
+    )
+    const url = new URL(result)
+
+    expect(url.searchParams.get('sslmode')).toBe('require')
+    expect(url.searchParams.get('uselibpqcompat')).toBe('true')
+  })
+
+  it('supports Supabase pooler connections', () => {
+    const result = normalizeSupabaseSslConnection(
+      'postgresql://user:password@aws-0-us-east-1.pooler.supabase.com:5432/postgres',
+    )
+    const url = new URL(result)
+
+    expect(url.searchParams.get('sslmode')).toBe('require')
+    expect(url.searchParams.get('uselibpqcompat')).toBe('true')
+  })
+
+  it('does not change TLS settings for non-Supabase hosts', () => {
+    const connectionString =
+      'postgresql://user:password@database.example.com:5432/postgres?sslmode=verify-full'
+
+    expect(normalizeSupabaseSslConnection(connectionString)).toBe(connectionString)
+  })
+
+  it('rejects non-Postgres connection URLs without including their value', () => {
+    expect(() =>
+      normalizeSupabaseSslConnection('https://user:secret@example.com/database'),
+    ).toThrow('The configured database URL must use the Postgres protocol')
+  })
+})


### PR DESCRIPTION
## Summary
- normalize Supabase direct and pooler URLs to encrypted libpq-compatible SSL mode
- restrict compatibility behavior to Supabase-owned hostnames
- add regression coverage for direct, pooler, non-Supabase, and invalid URLs

## Production diagnosis
The production build for merge commit `4bdc52e` reached the recovery runner but failed with `self-signed certificate in certificate chain`. Supabase documents `sslmode=require` semantics that encrypt the connection without CA verification; the current `pg` release otherwise interprets it as `verify-full`.

## Verification
- `npx vitest run tests/unit/lib/postgres-connection.test.ts`
- `npm test -- --run` (48 passed)
- `npm run lint` (0 errors; 14 existing warnings)
- `npm run type-check`
- `npm run build:local`
- `ai-trust-scan --pre-commit` (no leaks)

## Trust scan
The full repository scan continues to report three historical findings. The staged hotfix scan is clean.