### PR TITLE
Add admin ticket deletion and remove duplicate Capacity link

### DIFF
--- a/src/app/api/admin/tickets/[id]/route.ts
+++ b/src/app/api/admin/tickets/[id]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { writeAuditLog } from '@/lib/audit'
+import { normalizeDashboardRole } from '@/lib/require-role'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+type UserAuthRow = {
+  role: string
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const ticketId = z.string().uuid().safeParse(id)
+
+    if (!ticketId.success) {
+      return NextResponse.json({ error: 'Invalid ticket ID' }, { status: 400 })
+    }
+
+    const supabase = await createServerSupabaseClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: profile } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', user.id)
+      .single()
+
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+
+    if (normalizeDashboardRole((profile as UserAuthRow).role) !== 'super_admin') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { data: ticket, error: ticketError } = await supabase
+      .from('tickets')
+      .select('id, ticket_number, subject, status, organization_id')
+      .eq('id', ticketId.data)
+      .maybeSingle()
+
+    if (ticketError) {
+      console.error('Failed to load ticket for deletion:', ticketError)
+      return NextResponse.json({ error: 'Failed to load ticket' }, { status: 500 })
+    }
+
+    if (!ticket) {
+      return NextResponse.json({ error: 'Ticket not found' }, { status: 404 })
+    }
+
+    const { data: deletedTicket, error: deleteError } = await supabase
+      .from('tickets')
+      .delete()
+      .eq('id', ticketId.data)
+      .select('id')
+      .maybeSingle()
+
+    if (deleteError) {
+      console.error('Failed to delete ticket:', deleteError)
+      return NextResponse.json({ error: 'Failed to delete ticket' }, { status: 500 })
+    }
+
+    if (!deletedTicket) {
+      return NextResponse.json({ error: 'Ticket could not be deleted' }, { status: 409 })
+    }
+
+    await writeAuditLog({
+      action: 'ticket_deleted',
+      entity_type: 'ticket',
+      entity_id: deletedTicket.id,
+      old_values: {
+        ticket_number: ticket.ticket_number,
+        subject: ticket.subject,
+        status: ticket.status,
+        organization_id: ticket.organization_id,
+      },
+    })
+
+    return NextResponse.json({ success: true, deletedId: deletedTicket.id })
+  } catch (error) {
+    console.error('Ticket DELETE error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/dashboard/admin/tickets/page.tsx
+++ b/src/app/dashboard/admin/tickets/page.tsx
@@ -1,6 +1,7 @@
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { StaffTicketList } from '@/components/tickets/staff-ticket-list'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { normalizeDashboardRole } from '@/lib/require-role'
 import { AlertCircle } from 'lucide-react'
 import { redirect } from 'next/navigation'
 
@@ -32,7 +33,8 @@ export default async function AdminTicketsPage() {
   }
 
   const p = profile as { organization_id: string | null; role: string }
-  if (!['super_admin', 'staff', 'partner'].includes(p.role)) {
+  const role = normalizeDashboardRole(p.role)
+  if (!['super_admin', 'staff', 'partner'].includes(role)) {
     redirect('/dashboard')
   }
 
@@ -45,7 +47,7 @@ export default async function AdminTicketsPage() {
       assigned_to_user:users!assigned_to(id, profiles(name))
     `)
 
-  if (p.organization_id && p.role !== 'super_admin') {
+  if (p.organization_id && role !== 'super_admin') {
     ticketsQuery.eq('organization_id', p.organization_id)
   }
 
@@ -82,7 +84,10 @@ export default async function AdminTicketsPage() {
       </div>
 
       {/* Staff Ticket List */}
-      <StaffTicketList initialTickets={tickets || []} />
+      <StaffTicketList
+        initialTickets={tickets || []}
+        canDeleteTickets={role === 'super_admin'}
+      />
     </div>
   )
 }

--- a/src/app/dashboard/tickets/archive/page.tsx
+++ b/src/app/dashboard/tickets/archive/page.tsx
@@ -2,6 +2,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { TicketList } from "@/components/tickets/ticket-list";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { normalizeDashboardRole } from "@/lib/require-role";
 import { AlertCircle, ArrowLeft, Archive } from "lucide-react";
 import Link from "next/link";
 
@@ -22,6 +23,7 @@ export default async function TicketsArchivePage() {
 
   // Fetch organizations for filter (only for staff/admins)
   let organizations: Array<{ id: string; name: string }> = [];
+  let canDeleteTickets = false;
   if (user) {
     const { data: userProfile } = await supabase
       .from("users")
@@ -29,7 +31,10 @@ export default async function TicketsArchivePage() {
       .eq("id", user.id)
       .single();
 
-    if (userProfile?.role === "staff" || userProfile?.role === "super_admin") {
+    const role = normalizeDashboardRole(userProfile?.role);
+    canDeleteTickets = role === "super_admin";
+
+    if (role === "staff" || role === "super_admin") {
       const { data: orgs } = await supabase
         .from("organizations")
         .select("id, name")
@@ -112,7 +117,11 @@ export default async function TicketsArchivePage() {
           </Button>
         </div>
       ) : (
-        <TicketList initialTickets={tickets || []} organizations={organizations} />
+        <TicketList
+          initialTickets={tickets || []}
+          organizations={organizations}
+          canDeleteTickets={canDeleteTickets}
+        />
       )}
     </div>
   );

--- a/src/app/dashboard/tickets/page.tsx
+++ b/src/app/dashboard/tickets/page.tsx
@@ -2,6 +2,7 @@ import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { TicketList } from "@/components/tickets/ticket-list";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { normalizeDashboardRole } from "@/lib/require-role";
 import { PlusCircle, AlertCircle } from "lucide-react";
 import Link from "next/link";
 
@@ -21,6 +22,7 @@ export default async function TicketsPage() {
 
   // Fetch organizations for filter (only for staff/admins)
   let organizations: Array<{ id: string; name: string }> = [];
+  let canDeleteTickets = false;
   if (user) {
     const { data: userProfile } = await (supabase as any)
       .from("users")
@@ -28,7 +30,10 @@ export default async function TicketsPage() {
       .eq("id", user.id)
       .single();
 
-    if ((userProfile as any)?.role === "staff" || (userProfile as any)?.role === "super_admin") {
+    const role = normalizeDashboardRole((userProfile as { role?: string } | null)?.role);
+    canDeleteTickets = role === "super_admin";
+
+    if (role === "staff" || role === "super_admin") {
       const { data: orgs } = await (supabase as any)
         .from("organizations")
         .select("id, name")
@@ -94,7 +99,11 @@ export default async function TicketsPage() {
         </div>
       </div>
 
-      <TicketList initialTickets={tickets || []} organizations={organizations} />
+      <TicketList
+        initialTickets={tickets || []}
+        organizations={organizations}
+        canDeleteTickets={canDeleteTickets}
+      />
     </div>
   );
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -168,7 +168,6 @@ const navGroups: { label: string; items: NavItem[] }[] = [
       { href: "/dashboard/admin/ai-usage", icon: BarChart3, label: "AI Usage" },
       { href: "/dashboard/audit", icon: History, label: "Audit Log" },
       { href: "/dashboard/admin/error-logs", icon: Bug, label: "Error Log" },
-      { href: "/dashboard/capacity", icon: BarChart3, label: "Capacity" },
     ],
   },
 ];

--- a/src/components/tickets/DeleteTicketButton.tsx
+++ b/src/components/tickets/DeleteTicketButton.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2, Trash2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { toast } from '@/components/ui/use-toast'
+
+type DeleteTicketButtonProps = {
+  ticketId: string
+  ticketNumber: number
+  subject: string
+  onDeleted?: () => void | Promise<void>
+}
+
+export function DeleteTicketButton({
+  ticketId,
+  ticketNumber,
+  subject,
+  onDeleted,
+}: DeleteTicketButtonProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete() {
+    setIsDeleting(true)
+    setError(null)
+
+    try {
+      const endpoint = '/api/admin/tickets/' + encodeURIComponent(ticketId)
+      const response = await fetch(endpoint, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      })
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to delete ticket')
+      }
+
+      setOpen(false)
+      toast({ title: ['Ticket', '#' + ticketNumber, 'deleted'].join(' ') })
+      await onDeleted?.()
+      router.refresh()
+    } catch (deleteError) {
+      const message =
+        deleteError instanceof Error ? deleteError.message : 'Failed to delete ticket'
+      setError(message)
+      toast({
+        title: 'Ticket was not deleted',
+        description: message,
+        variant: 'destructive',
+      })
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Trash2 aria-hidden="true" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent onClick={(event) => event.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete ticket #{ticketNumber}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes “{subject}” and its comments, attachment links,
+            notifications, and deliverables. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            disabled={isDeleting}
+            onClick={(event) => {
+              event.preventDefault()
+              void handleDelete()
+            }}
+          >
+            {isDeleting ? (
+              <>
+                <Loader2 className="animate-spin" aria-hidden="true" />
+                Deleting...
+              </>
+            ) : (
+              'Delete ticket'
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/tickets/staff-ticket-list.tsx
+++ b/src/components/tickets/staff-ticket-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createClient } from '@/lib/supabase/client'
 import { useRealtimeTickets } from '@/hooks/use-realtime-tickets'
 import {
@@ -38,6 +38,7 @@ import {
   type TicketPriority,
 } from '@/lib/ticket-priority'
 import { Database } from '@/types/database'
+import { DeleteTicketButton } from '@/components/tickets/DeleteTicketButton'
 
 type Ticket = Database['public']['Tables']['tickets']['Row']
 
@@ -54,6 +55,7 @@ interface TicketWithRelations extends Ticket {
 
 interface StaffTicketListProps {
   initialTickets: TicketWithRelations[]
+  canDeleteTickets?: boolean
 }
 
 const STATUS_OPTIONS = [
@@ -89,9 +91,13 @@ const STATUS_STYLES: Record<string, string> = {
   closed: 'bg-slate-100 text-slate-600 border-slate-200',
 }
 
-export function StaffTicketList({ initialTickets }: StaffTicketListProps) {
+export function StaffTicketList({
+  initialTickets,
+  canDeleteTickets = false,
+}: StaffTicketListProps) {
   const supabase = createClient()
   const router = useRouter()
+  const queryClient = useQueryClient()
   useRealtimeTickets()
 
   const [searchTerm, setSearchTerm] = useState('')
@@ -382,12 +388,16 @@ export function StaffTicketList({ initialTickets }: StaffTicketListProps) {
               <TableHead className="font-semibold">Assigned To</TableHead>
               <TableHead className="font-semibold">Due Date</TableHead>
               <TableHead className="font-semibold text-right">Created</TableHead>
+              {canDeleteTickets && <TableHead className="font-semibold text-right">Actions</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
             {filteredTickets.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={8} className="h-32 text-center text-slate-500 italic">
+                <TableCell
+                  colSpan={8 + (canDeleteTickets ? 1 : 0)}
+                  className="h-32 text-center text-slate-500 italic"
+                >
                   {hasActiveFilters ? 'No tickets match your filters.' : 'No tickets found.'}
                 </TableCell>
               </TableRow>
@@ -445,6 +455,22 @@ export function StaffTicketList({ initialTickets }: StaffTicketListProps) {
                     <TableCell className="text-right text-slate-500 text-sm whitespace-nowrap">
                       {ticket.created_at ? formatDate(ticket.created_at) : '-'}
                     </TableCell>
+                    {canDeleteTickets && (
+                      <TableCell
+                        className="text-right"
+                        onClick={(event) => event.stopPropagation()}
+                        onKeyDown={(event) => event.stopPropagation()}
+                      >
+                        <DeleteTicketButton
+                          ticketId={ticket.id}
+                          ticketNumber={ticket.ticket_number}
+                          subject={ticket.subject}
+                          onDeleted={() =>
+                            queryClient.invalidateQueries({ queryKey: ['staff-tickets'] })
+                          }
+                        />
+                      </TableCell>
+                    )}
                   </TableRow>
                 )
               })

--- a/src/components/tickets/ticket-list.tsx
+++ b/src/components/tickets/ticket-list.tsx
@@ -124,7 +124,10 @@ export function TicketList({
     initialData: { tickets: initialTickets, totalCount: initialTickets.length },
   })
 
-  const tickets = ticketsResponse?.tickets ?? []
+  const tickets = useMemo(
+    () => ticketsResponse?.tickets ?? [],
+    [ticketsResponse?.tickets]
+  )
   const totalCount = ticketsResponse?.totalCount ?? 0
   const totalPages = Math.ceil(totalCount / PAGE_SIZE)
 

--- a/src/components/tickets/ticket-list.tsx
+++ b/src/components/tickets/ticket-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createClient } from '@/lib/supabase/client'
 import { useRealtimeTickets } from '@/hooks/use-realtime-tickets'
 import {
@@ -29,6 +29,7 @@ import { Button } from '@/components/ui/button'
 import { Database } from '@/types/database'
 import { cn } from '@/lib/utils'
 import { getCombinedSLAStatus, getSLARowColor } from '@/lib/sla-status'
+import { DeleteTicketButton } from '@/components/tickets/DeleteTicketButton'
 import {
   Tooltip,
   TooltipContent,
@@ -50,6 +51,7 @@ type Ticket = Database['public']['Tables']['tickets']['Row'] & {
 interface TicketListProps {
   initialTickets: Ticket[]
   organizations?: Array<{ id: string; name: string }>
+  canDeleteTickets?: boolean
 }
 
 const STATUS_OPTIONS = [
@@ -78,8 +80,13 @@ const SLA_FILTER_OPTIONS = [
   { value: 'on-track', label: 'On Track' },
 ]
 
-export function TicketList({ initialTickets, organizations }: TicketListProps) {
+export function TicketList({
+  initialTickets,
+  organizations,
+  canDeleteTickets = false,
+}: TicketListProps) {
   const supabase = createClient()
+  const queryClient = useQueryClient()
   useRealtimeTickets()
 
   const [searchTerm, setSearchTerm] = useState('')
@@ -302,6 +309,10 @@ export function TicketList({ initialTickets, organizations }: TicketListProps) {
             tickets={priorityTickets} 
             showOrgColumn={true} 
             hasActiveFilters={hasActiveFilters}
+            canDeleteTickets={canDeleteTickets}
+            onTicketDeleted={async () => {
+              await queryClient.invalidateQueries({ queryKey: ['tickets'] })
+            }}
           />
         </div>
       )}
@@ -315,6 +326,10 @@ export function TicketList({ initialTickets, organizations }: TicketListProps) {
           tickets={otherTickets} 
           showOrgColumn={true}
           hasActiveFilters={hasActiveFilters}
+          canDeleteTickets={canDeleteTickets}
+          onTicketDeleted={async () => {
+            await queryClient.invalidateQueries({ queryKey: ['tickets'] })
+          }}
         />
       </div>
 
@@ -355,11 +370,15 @@ export function TicketList({ initialTickets, organizations }: TicketListProps) {
 function TicketTable({ 
   tickets, 
   showOrgColumn,
-  hasActiveFilters 
+  hasActiveFilters,
+  canDeleteTickets,
+  onTicketDeleted,
 }: { 
   tickets: Ticket[]
   showOrgColumn: boolean
   hasActiveFilters: boolean
+  canDeleteTickets: boolean
+  onTicketDeleted: () => Promise<void>
 }) {
   const router = useRouter()
 
@@ -377,12 +396,16 @@ function TicketTable({
             <TableHead className="font-semibold">Priority</TableHead>
             <TableHead className="font-semibold">SLA Status</TableHead>
             <TableHead className="font-semibold text-right">Created</TableHead>
+            {canDeleteTickets && <TableHead className="font-semibold text-right">Actions</TableHead>}
           </TableRow>
         </TableHeader>
         <TableBody>
           {tickets.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={showOrgColumn ? 7 : 6} className="h-32 text-center text-slate-500 italic">
+              <TableCell
+                colSpan={(showOrgColumn ? 7 : 6) + (canDeleteTickets ? 1 : 0)}
+                className="h-32 text-center text-slate-500 italic"
+              >
                 {hasActiveFilters ? 'No tickets match your filters.' : 'No tickets found.'}
               </TableCell>
             </TableRow>
@@ -450,6 +473,20 @@ function TicketTable({
                   <TableCell className="text-right text-slate-500 text-sm whitespace-nowrap">
                     {ticket.created_at ? formatDate(ticket.created_at) : '—'}
                   </TableCell>
+                  {canDeleteTickets && (
+                    <TableCell
+                      className="text-right"
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <DeleteTicketButton
+                        ticketId={ticket.id}
+                        ticketNumber={ticket.ticket_number}
+                        subject={ticket.subject}
+                        onDeleted={onTicketDeleted}
+                      />
+                    </TableCell>
+                  )}
                 </TableRow>
               )
             })

--- a/supabase/migrations/20260807000000_admin_ticket_deletion.sql
+++ b/supabase/migrations/20260807000000_admin_ticket_deletion.sql
@@ -1,0 +1,92 @@
+-- Restrict ticket deletion to super admins and make optional ticket links non-blocking.
+
+DROP POLICY IF EXISTS "Staff can manage all tickets" ON public.tickets;
+DROP POLICY IF EXISTS "Partners can manage their and client tickets" ON public.tickets;
+DROP POLICY IF EXISTS "Clients can manage own tickets" ON public.tickets;
+DROP POLICY IF EXISTS "Clients can manage organization tickets" ON public.tickets;
+
+CREATE POLICY "Staff can view all tickets"
+  ON public.tickets FOR SELECT TO authenticated
+  USING (is_admin_or_staff());
+
+CREATE POLICY "Staff can create tickets"
+  ON public.tickets FOR INSERT TO authenticated
+  WITH CHECK (is_admin_or_staff());
+
+CREATE POLICY "Staff can update tickets"
+  ON public.tickets FOR UPDATE TO authenticated
+  USING (is_admin_or_staff())
+  WITH CHECK (is_admin_or_staff());
+
+CREATE POLICY "Partners can create organization tickets"
+  ON public.tickets FOR INSERT TO authenticated
+  WITH CHECK (
+    get_user_role() IN ('partner', 'partner_staff')
+    AND (
+      organization_id = get_user_organization_id()
+      OR organization_id IN (
+        SELECT id FROM public.organizations
+        WHERE parent_org_id = get_user_organization_id()
+      )
+    )
+  );
+
+CREATE POLICY "Partners can update organization tickets"
+  ON public.tickets FOR UPDATE TO authenticated
+  USING (
+    get_user_role() IN ('partner', 'partner_staff')
+    AND (
+      organization_id = get_user_organization_id()
+      OR organization_id IN (
+        SELECT id FROM public.organizations
+        WHERE parent_org_id = get_user_organization_id()
+      )
+    )
+  )
+  WITH CHECK (
+    get_user_role() IN ('partner', 'partner_staff')
+    AND (
+      organization_id = get_user_organization_id()
+      OR organization_id IN (
+        SELECT id FROM public.organizations
+        WHERE parent_org_id = get_user_organization_id()
+      )
+    )
+  );
+
+CREATE POLICY "Clients can create organization tickets"
+  ON public.tickets FOR INSERT TO authenticated
+  WITH CHECK (
+    get_user_role() = 'client'
+    AND organization_id = get_user_organization_id()
+  );
+
+CREATE POLICY "Clients can update organization tickets"
+  ON public.tickets FOR UPDATE TO authenticated
+  USING (
+    get_user_role() = 'client'
+    AND organization_id = get_user_organization_id()
+  )
+  WITH CHECK (
+    get_user_role() = 'client'
+    AND organization_id = get_user_organization_id()
+  );
+
+CREATE POLICY "Super admins can delete tickets"
+  ON public.tickets FOR DELETE TO authenticated
+  USING (is_super_admin());
+
+ALTER TABLE public.tickets
+  DROP CONSTRAINT IF EXISTS tickets_parent_ticket_id_fkey,
+  ADD CONSTRAINT tickets_parent_ticket_id_fkey
+    FOREIGN KEY (parent_ticket_id) REFERENCES public.tickets(id) ON DELETE SET NULL;
+
+ALTER TABLE public.conversations
+  DROP CONSTRAINT IF EXISTS conversations_ticket_id_fkey,
+  ADD CONSTRAINT conversations_ticket_id_fkey
+    FOREIGN KEY (ticket_id) REFERENCES public.tickets(id) ON DELETE SET NULL;
+
+ALTER TABLE public.chat_sessions
+  DROP CONSTRAINT IF EXISTS chat_sessions_converted_ticket_id_fkey,
+  ADD CONSTRAINT chat_sessions_converted_ticket_id_fkey
+    FOREIGN KEY (converted_ticket_id) REFERENCES public.tickets(id) ON DELETE SET NULL;

--- a/tests/unit/api/admin-ticket-delete.test.ts
+++ b/tests/unit/api/admin-ticket-delete.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { DELETE } from '@/app/api/admin/tickets/[id]/route'
+import { writeAuditLog } from '@/lib/audit'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabaseClient: vi.fn(),
+}))
+
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: vi.fn(),
+}))
+
+const ticketId = 'd12abe39-5448-4563-9ac6-2dd53da9fcfc'
+const createServerSupabaseClientMock = vi.mocked(createServerSupabaseClient)
+const writeAuditLogMock = vi.mocked(writeAuditLog)
+
+type TicketFixture = {
+  authenticated?: boolean
+  role?: string
+  ticket?: {
+    id: string
+    ticket_number: number
+    subject: string
+    status: string
+    organization_id: string
+  } | null
+  deletedTicket?: { id: string } | null
+  ticketError?: { message: string } | null
+  deleteError?: { message: string } | null
+}
+
+function createSupabaseFixture({
+  authenticated = true,
+  role = 'super_admin',
+  ticket = {
+    id: ticketId,
+    ticket_number: 42,
+    subject: 'Cannot access account',
+    status: 'open',
+    organization_id: '89f04a30-7d6b-4e65-9e19-18cb95615e8b',
+  },
+  deletedTicket = { id: ticketId },
+  ticketError = null,
+  deleteError = null,
+}: TicketFixture = {}) {
+  const deleteMaybeSingle = vi.fn().mockResolvedValue({
+    data: deletedTicket,
+    error: deleteError,
+  })
+  const deleteTicket = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      select: vi.fn(() => ({ maybeSingle: deleteMaybeSingle })),
+    })),
+  }))
+
+  return {
+    deleteTicket,
+    client: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: authenticated ? { id: 'admin-user' } : null },
+          error: null,
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: authenticated ? { role } : null,
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: ticket, error: ticketError }),
+            })),
+          })),
+          delete: deleteTicket,
+        }
+      }),
+    },
+  }
+}
+
+async function deleteTicket(id = ticketId) {
+  return DELETE(
+    new NextRequest(`http://localhost/api/admin/tickets/${id}`, { method: 'DELETE' }),
+    { params: Promise.resolve({ id }) },
+  )
+}
+
+describe('DELETE /api/admin/tickets/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects invalid ticket IDs before accessing the database', async () => {
+    const response = await deleteTicket('not-a-uuid')
+
+    expect(response.status).toBe(400)
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled()
+  })
+
+  it('requires authentication', async () => {
+    const fixture = createSupabaseFixture({ authenticated: false })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteTicket()
+
+    expect(response.status).toBe(401)
+  })
+
+  it('does not allow staff to delete tickets', async () => {
+    const fixture = createSupabaseFixture({ role: 'staff' })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteTicket()
+
+    expect(response.status).toBe(403)
+    expect(fixture.deleteTicket).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the ticket does not exist', async () => {
+    const fixture = createSupabaseFixture({ ticket: null })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteTicket()
+
+    expect(response.status).toBe(404)
+    expect(fixture.deleteTicket).not.toHaveBeenCalled()
+  })
+
+  it('deletes a ticket for legacy admin roles and records an audit event', async () => {
+    const fixture = createSupabaseFixture({ role: 'admin' })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteTicket()
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true, deletedId: ticketId })
+    expect(fixture.deleteTicket).toHaveBeenCalledOnce()
+    expect(writeAuditLogMock).toHaveBeenCalledWith({
+      action: 'ticket_deleted',
+      entity_type: 'ticket',
+      entity_id: ticketId,
+      old_values: {
+        ticket_number: 42,
+        subject: 'Cannot access account',
+        status: 'open',
+        organization_id: '89f04a30-7d6b-4e65-9e19-18cb95615e8b',
+      },
+    })
+  })
+
+  it('does not audit when deletion fails', async () => {
+    const fixture = createSupabaseFixture({ deleteError: { message: 'constraint error' } })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteTicket()
+
+    expect(response.status).toBe(500)
+    expect(writeAuditLogMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/components/sidebar-toggle.test.tsx
+++ b/tests/unit/components/sidebar-toggle.test.tsx
@@ -129,6 +129,24 @@ describe("Sidebar Toggle Functionality", () => {
     rerender(<DashboardSidebar profile={profile} />);
   });
 
+  it("shows Capacity only once for super admins", () => {
+    const profile = {
+      id: "test-id",
+      organization_id: "org-id",
+      email: "admin@example.com",
+      role: "super_admin" as const,
+      is_account_manager: true,
+      name: "Admin User",
+      avatar_url: null,
+      organization_name: "Test Org",
+      organization_slug: "test-org",
+    };
+
+    render(<DashboardSidebar profile={profile} />);
+
+    expect(screen.getAllByRole("link", { name: "Capacity" })).toHaveLength(1);
+  });
+
   it("initializes from localStorage when available", () => {
     // Pre-populate localStorage
     localStorage.setItem("sidebar-collapsed-sections", JSON.stringify(["Admin"]));

--- a/tests/unit/tickets/DeleteTicketButton.test.tsx
+++ b/tests/unit/tickets/DeleteTicketButton.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DeleteTicketButton } from '@/components/tickets/DeleteTicketButton'
+
+const { refresh, toast } = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  toast: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}))
+
+vi.mock('@/components/ui/use-toast', () => ({ toast }))
+
+describe('DeleteTicketButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('confirms and deletes a ticket', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ success: true }),
+    })
+    const onDeleted = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <DeleteTicketButton
+        ticketId="d12abe39-5448-4563-9ac6-2dd53da9fcfc"
+        ticketNumber={42}
+        subject="Cannot access account"
+        onDeleted={onDeleted}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(screen.getByText('Delete ticket #42?')).toBeInTheDocument()
+    expect(screen.getByText(/Cannot access account/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete ticket' }))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/tickets/d12abe39-5448-4563-9ac6-2dd53da9fcfc',
+        { method: 'DELETE', credentials: 'same-origin' },
+      ),
+    )
+    expect(onDeleted).toHaveBeenCalledOnce()
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(toast).toHaveBeenCalledWith({ title: 'Ticket #42 deleted' })
+  })
+
+  it('keeps the confirmation open and displays API errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: vi.fn().mockResolvedValue({ error: 'Ticket could not be deleted' }),
+      }),
+    )
+
+    render(
+      <DeleteTicketButton
+        ticketId="d12abe39-5448-4563-9ac6-2dd53da9fcfc"
+        ticketNumber={42}
+        subject="Cannot access account"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete ticket' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Ticket could not be deleted')
+    expect(screen.getByText('Delete ticket #42?')).toBeInTheDocument()
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- add an admin-only, confirmed delete action for support tickets on the ticket lists
- enforce super-admin deletion in the API and Supabase RLS, with audit logging
- make optional ticket relationships use `ON DELETE SET NULL` while dependent ticket data cascades
- remove the duplicate Capacity navigation item from the Admin section

## Why

Admins need a safe way to permanently remove support tickets, while staff and client roles must remain unable to delete them. Capacity was also displayed twice in the sidebar.

## Validation

- `npx vitest run tests/unit/api/admin-ticket-delete.test.ts tests/unit/tickets/DeleteTicketButton.test.tsx tests/unit/components/sidebar-toggle.test.tsx`
- `npm test -- --run` (66 tests)
- `npm run lint` (0 errors; 14 existing warnings)
- `npm run type-check`
- `npm run build:local`
- `ai-trust-scan --pre-commit` (no leaks)
