### PR TITLE
feat(clients): add admin client management controls

### DIFF
--- a/src/app/api/admin/clients/[id]/route.ts
+++ b/src/app/api/admin/clients/[id]/route.ts
@@ -1,0 +1,307 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { writeAuditLog } from '@/lib/audit'
+import { normalizeDashboardRole } from '@/lib/require-role'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+const updateClientTypeSchema = z.object({
+  type: z.enum(['client', 'partner']),
+})
+
+type UserAuthRow = {
+  role: string
+}
+
+type OrganizationRow = {
+  id: string
+  name: string
+  slug: string
+  type: string
+  status: string | null
+  parent_org_id: string | null
+  custom_domain: string | null
+  custom_domain_verified: boolean | null
+}
+
+async function requireSuperAdmin() {
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: 'Profile not found' }, { status: 404 }),
+    }
+  }
+
+  if (normalizeDashboardRole((profile as UserAuthRow).role) !== 'super_admin') {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    }
+  }
+
+  return { ok: true as const, supabase }
+}
+
+async function loadClient(
+  supabase: Awaited<ReturnType<typeof createServerSupabaseClient>>,
+  organizationId: string,
+) {
+  return supabase
+    .from('organizations')
+    .select(
+      'id, name, slug, type, status, parent_org_id, custom_domain, custom_domain_verified',
+    )
+    .eq('id', organizationId)
+    .maybeSingle()
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const organizationId = z.string().uuid().safeParse(id)
+
+    if (!organizationId.success) {
+      return NextResponse.json({ error: 'Invalid client ID' }, { status: 400 })
+    }
+
+    const body = await request.json().catch(() => null)
+    const input = updateClientTypeSchema.safeParse(body)
+
+    if (!input.success) {
+      return NextResponse.json(
+        { error: 'Client role must be standard client or white-label partner' },
+        { status: 400 },
+      )
+    }
+
+    const access = await requireSuperAdmin()
+    if (!access.ok) return access.response
+
+    const { data: existingClient, error: clientError } = await loadClient(
+      access.supabase,
+      organizationId.data,
+    )
+
+    if (clientError) {
+      console.error('Failed to load client for role update:', clientError)
+      return NextResponse.json({ error: 'Failed to load client' }, { status: 500 })
+    }
+
+    const client = existingClient as OrganizationRow | null
+    if (!client) {
+      return NextResponse.json({ error: 'Client not found' }, { status: 404 })
+    }
+
+    if (client.type === 'kre8ivtech') {
+      return NextResponse.json(
+        { error: 'The main Kre8ivTech organization role cannot be changed' },
+        { status: 409 },
+      )
+    }
+
+    if (input.data.type === 'client' && client.type === 'partner') {
+      const { data: childClient, error: childError } = await access.supabase
+        .from('organizations')
+        .select('id')
+        .eq('parent_org_id', client.id)
+        .limit(1)
+        .maybeSingle()
+
+      if (childError) {
+        console.error('Failed to check white-label child clients:', childError)
+        return NextResponse.json({ error: 'Failed to validate client role change' }, { status: 500 })
+      }
+
+      if (childClient) {
+        return NextResponse.json(
+          { error: 'Move or remove this partner’s child clients before disabling white-label access' },
+          { status: 409 },
+        )
+      }
+    }
+
+    if (client.type === input.data.type) {
+      return NextResponse.json({ success: true, data: client })
+    }
+
+    const updateData: Record<string, unknown> = {
+      type: input.data.type,
+      updated_at: new Date().toISOString(),
+    }
+
+    if (input.data.type === 'partner') {
+      const { data: mainOrganization } = await access.supabase
+        .from('organizations')
+        .select('id')
+        .eq('type', 'kre8ivtech')
+        .limit(1)
+        .maybeSingle()
+
+      updateData.parent_org_id = mainOrganization?.id ?? null
+    } else {
+      updateData.custom_domain = null
+      updateData.custom_domain_verified = false
+      updateData.custom_domain_verified_at = null
+    }
+
+    const { data: updatedClient, error: updateError } = await access.supabase
+      .from('organizations')
+      .update(updateData)
+      .eq('id', client.id)
+      .select(
+        'id, name, slug, type, status, parent_org_id, custom_domain, custom_domain_verified',
+      )
+      .maybeSingle()
+
+    if (updateError) {
+      console.error('Failed to update client role:', updateError)
+      return NextResponse.json({ error: 'Failed to update client role' }, { status: 500 })
+    }
+
+    if (!updatedClient) {
+      return NextResponse.json({ error: 'Client role could not be updated' }, { status: 409 })
+    }
+
+    await writeAuditLog({
+      action: 'client_role_updated',
+      entity_type: 'organization',
+      entity_id: client.id,
+      old_values: {
+        type: client.type,
+        parent_org_id: client.parent_org_id,
+        custom_domain: client.custom_domain,
+        custom_domain_verified: client.custom_domain_verified,
+      },
+      new_values: {
+        type: input.data.type,
+        parent_org_id: updatedClient.parent_org_id,
+        custom_domain: updatedClient.custom_domain,
+        custom_domain_verified: updatedClient.custom_domain_verified,
+      },
+    })
+
+    return NextResponse.json({ success: true, data: updatedClient })
+  } catch (error) {
+    console.error('Client role PATCH error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const organizationId = z.string().uuid().safeParse(id)
+
+    if (!organizationId.success) {
+      return NextResponse.json({ error: 'Invalid client ID' }, { status: 400 })
+    }
+
+    const access = await requireSuperAdmin()
+    if (!access.ok) return access.response
+
+    const { data: existingClient, error: clientError } = await loadClient(
+      access.supabase,
+      organizationId.data,
+    )
+
+    if (clientError) {
+      console.error('Failed to load client for deletion:', clientError)
+      return NextResponse.json({ error: 'Failed to load client' }, { status: 500 })
+    }
+
+    const client = existingClient as OrganizationRow | null
+    if (!client) {
+      return NextResponse.json({ error: 'Client not found' }, { status: 404 })
+    }
+
+    if (client.type === 'kre8ivtech') {
+      return NextResponse.json(
+        { error: 'The main Kre8ivTech organization cannot be deleted' },
+        { status: 409 },
+      )
+    }
+
+    if (client.type === 'partner') {
+      const { data: childClient, error: childError } = await access.supabase
+        .from('organizations')
+        .select('id')
+        .eq('parent_org_id', client.id)
+        .limit(1)
+        .maybeSingle()
+
+      if (childError) {
+        console.error('Failed to check partner child clients before deletion:', childError)
+        return NextResponse.json({ error: 'Failed to validate client deletion' }, { status: 500 })
+      }
+
+      if (childClient) {
+        return NextResponse.json(
+          { error: 'Move or delete this partner’s child clients before deleting the partner' },
+          { status: 409 },
+        )
+      }
+    }
+
+    const { data: deactivatedClient, error: updateError } = await access.supabase
+      .from('organizations')
+      .update({
+        status: 'inactive',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', client.id)
+      .select('id, status')
+      .maybeSingle()
+
+    if (updateError) {
+      console.error('Failed to deactivate client:', updateError)
+      return NextResponse.json({ error: 'Failed to delete client' }, { status: 500 })
+    }
+
+    if (!deactivatedClient) {
+      return NextResponse.json({ error: 'Client could not be deleted' }, { status: 409 })
+    }
+
+    await writeAuditLog({
+      action: 'client_deleted',
+      entity_type: 'organization',
+      entity_id: client.id,
+      old_values: {
+        name: client.name,
+        slug: client.slug,
+        type: client.type,
+        status: client.status,
+      },
+      new_values: { status: 'inactive' },
+      details: { deletion_mode: 'deactivated_to_preserve_history' },
+    })
+
+    return NextResponse.json({ success: true, deletedId: client.id })
+  } catch (error) {
+    console.error('Client DELETE error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/organizations/[id]/route.ts
+++ b/src/app/api/organizations/[id]/route.ts
@@ -156,6 +156,15 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     const input = result.data;
 
+    // Organization type controls tenant-level access and must only be changed
+    // through the audited super-admin client-management endpoint.
+    if (input.type !== undefined) {
+      return NextResponse.json(
+        { error: "Use the admin client controls to change an organization role" },
+        { status: 403 }
+      );
+    }
+
     // If slug is being changed, check uniqueness
     if (input.slug) {
       const { data: existingOrg } = await supabase
@@ -173,14 +182,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // Partners cannot change organization type to partner
-    if (access.role === "partner" && input.type === "partner") {
-      return NextResponse.json(
-        { error: "Partners cannot create partner organizations" },
-        { status: 403 }
-      );
-    }
-
     // Build update object
     const updateData: Record<string, unknown> = {
       updated_at: new Date().toISOString(),
@@ -188,7 +189,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     if (input.name !== undefined) updateData.name = input.name;
     if (input.slug !== undefined) updateData.slug = input.slug;
-    if (input.type !== undefined) updateData.type = input.type;
     if (input.status !== undefined) updateData.status = input.status;
     
     // Only admin/staff/partners can update branding (not clients)

--- a/src/app/dashboard/clients/[id]/page.tsx
+++ b/src/app/dashboard/clients/[id]/page.tsx
@@ -15,6 +15,8 @@ import { Building2, ChevronLeft, Ticket, Settings, Users, CreditCard } from 'luc
 import { OrganizationSettingsForm } from '@/components/organizations/organization-settings-form'
 import { OrganizationUsersList } from '@/components/organizations/organization-users-list'
 import { OrganizationPlanInfo } from '@/components/organizations/organization-plan-info'
+import { ClientAdminControls } from '@/components/clients/ClientAdminControls'
+import { normalizeDashboardRole } from '@/lib/require-role'
 
 export default async function ClientOrgPage({
   params,
@@ -44,9 +46,10 @@ export default async function ClientOrgPage({
   const prof = profile as ProfileRow | null
   const isOwnOrg = prof?.organization_id === org.id
   const isChildOrg = org.parent_org_id === prof?.organization_id
-  const isSuperAdmin = prof?.role === "super_admin"
-  const isStaff = prof?.role === "staff"
-  const isPartner = prof?.role === "partner" || prof?.role === "partner_staff"
+  const role = normalizeDashboardRole(prof?.role)
+  const isSuperAdmin = role === 'super_admin'
+  const isStaff = role === 'staff'
+  const isPartner = role === 'partner' || role === 'partner_staff'
   const canView = isOwnOrg || isChildOrg || isSuperAdmin || isStaff
 
   if (!canView) notFound()
@@ -154,6 +157,15 @@ export default async function ClientOrgPage({
           </Badge>
         </div>
       </div>
+
+      {isSuperAdmin && org.type !== 'kre8ivtech' && (
+        <ClientAdminControls
+          clientId={org.id}
+          clientName={org.name}
+          initialType={org.type === 'partner' ? 'partner' : 'client'}
+          status={org.status}
+        />
+      )}
 
       {/* Quick Stats */}
       <div className="grid gap-4 md:grid-cols-4">

--- a/src/components/clients/ClientAdminControls.tsx
+++ b/src/components/clients/ClientAdminControls.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Globe2, Loader2, Save, Trash2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { toast } from '@/components/ui/use-toast'
+
+type ClientAdminControlsProps = {
+  clientId: string
+  clientName: string
+  initialType: 'client' | 'partner'
+  status: string | null
+}
+
+type ApiPayload = {
+  error?: string
+}
+
+export function ClientAdminControls({
+  clientId,
+  clientName,
+  initialType,
+  status,
+}: ClientAdminControlsProps) {
+  const router = useRouter()
+  const [clientType, setClientType] = useState(initialType)
+  const [savedType, setSavedType] = useState(initialType)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [roleError, setRoleError] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const endpoint = '/api/admin/clients/' + encodeURIComponent(clientId)
+
+  async function saveClientType() {
+    setIsSaving(true)
+    setRoleError(null)
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: clientType }),
+      })
+      const payload = (await response.json().catch(() => null)) as ApiPayload | null
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to update client role')
+      }
+
+      setSavedType(clientType)
+      toast({
+        title: 'Client role updated',
+        description:
+          clientType === 'partner'
+            ? `${clientName} is now a white-label partner.`
+            : `${clientName} is now a standard client.`,
+      })
+      router.refresh()
+    } catch (saveError) {
+      const message = saveError instanceof Error ? saveError.message : 'Failed to update client role'
+      setRoleError(message)
+      toast({ title: 'Client role was not updated', description: message, variant: 'destructive' })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function deleteClient() {
+    setIsDeleting(true)
+    setDeleteError(null)
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      })
+      const payload = (await response.json().catch(() => null)) as ApiPayload | null
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Failed to delete client')
+      }
+
+      setDeleteOpen(false)
+      toast({ title: `${clientName} deleted` })
+      router.push('/dashboard/clients')
+      router.refresh()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete client'
+      setDeleteError(message)
+      toast({ title: 'Client was not deleted', description: message, variant: 'destructive' })
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <Card className="border-amber-200 bg-amber-50/40">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Globe2 className="h-5 w-5 text-amber-700" aria-hidden="true" />
+          Admin controls
+        </CardTitle>
+        <CardDescription>
+          Set the client’s portal role or remove it from active client management.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex-1 space-y-2">
+            <Label htmlFor="client-role">Client role</Label>
+            <Select value={clientType} onValueChange={(value: 'client' | 'partner') => setClientType(value)}>
+              <SelectTrigger id="client-role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="client">Standard client (no white-label)</SelectItem>
+                <SelectItem value="partner">White-label partner</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            type="button"
+            onClick={() => void saveClientType()}
+            disabled={isSaving || clientType === savedType}
+          >
+            {isSaving ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : (
+              <Save aria-hidden="true" />
+            )}
+            {isSaving ? 'Saving...' : 'Save role'}
+          </Button>
+        </div>
+
+        <div className="border-t border-amber-200 pt-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium text-slate-900">Delete client</p>
+              <p className="text-sm text-slate-600">
+                Deactivate this client while preserving its historical records.
+              </p>
+            </div>
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+              <AlertDialogTrigger asChild>
+                <Button type="button" variant="destructive" disabled={status === 'inactive'}>
+                  <Trash2 aria-hidden="true" />
+                  {status === 'inactive' ? 'Client deleted' : 'Delete client'}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete {clientName}?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This deactivates the client and removes it from active client management. Its
+                    invoices, contracts, tickets, files, and audit history are preserved. This
+                    action cannot be undone from the portal.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                {deleteError && (
+                  <p role="alert" className="text-sm text-destructive">
+                    {deleteError}
+                  </p>
+                )}
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    disabled={isDeleting}
+                    onClick={(event) => {
+                      event.preventDefault()
+                      void deleteClient()
+                    }}
+                  >
+                    {isDeleting ? (
+                      <>
+                        <Loader2 className="animate-spin" aria-hidden="true" />
+                        Deleting...
+                      </>
+                    ) : (
+                      'Delete client'
+                    )}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+
+        {roleError && (
+          <p role="alert" className="text-sm text-destructive">
+            {roleError}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/validators/organization.ts
+++ b/src/lib/validators/organization.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 // ORGANIZATION TYPE ENUMS
 // =============================================================================
 
-export const organizationTypeSchema = z.enum(['direct', 'partner', 'client'])
+export const organizationTypeSchema = z.enum(['kre8ivtech', 'partner', 'client'])
 export const organizationStatusSchema = z.enum(['active', 'inactive', 'suspended'])
 
 // =============================================================================

--- a/tests/unit/api/admin-client-management.test.ts
+++ b/tests/unit/api/admin-client-management.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { DELETE, PATCH } from '@/app/api/admin/clients/[id]/route'
+import { writeAuditLog } from '@/lib/audit'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabaseClient: vi.fn(),
+}))
+
+vi.mock('@/lib/audit', () => ({
+  writeAuditLog: vi.fn(),
+}))
+
+const clientId = '31784cdf-469c-4936-9219-34be1fe7fbc5'
+const mainOrgId = 'd12abe39-5448-4563-9ac6-2dd53da9fcfc'
+const createServerSupabaseClientMock = vi.mocked(createServerSupabaseClient)
+const writeAuditLogMock = vi.mocked(writeAuditLog)
+
+const defaultClient = {
+  id: clientId,
+  name: 'Acme Co',
+  slug: 'acme-co',
+  type: 'client',
+  status: 'active',
+  parent_org_id: null,
+  custom_domain: null,
+  custom_domain_verified: false,
+}
+
+type ClientFixtureOptions = {
+  authenticated?: boolean
+  role?: string
+  client?: typeof defaultClient | null
+  clientError?: { message: string } | null
+  childClient?: { id: string } | null
+  mainOrganization?: { id: string } | null
+  updatedClient?: Record<string, unknown> | null
+  updateError?: { message: string } | null
+}
+
+function createSupabaseFixture({
+  authenticated = true,
+  role = 'super_admin',
+  client = defaultClient,
+  clientError = null,
+  childClient = null,
+  mainOrganization = { id: mainOrgId },
+  updatedClient,
+  updateError = null,
+}: ClientFixtureOptions = {}) {
+  const updateMaybeSingle = vi.fn().mockResolvedValue({
+    data:
+      updatedClient === undefined
+        ? { ...client, type: 'partner', parent_org_id: mainOrgId }
+        : updatedClient,
+    error: updateError,
+  })
+  const updateOrganization = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      select: vi.fn(() => ({ maybeSingle: updateMaybeSingle })),
+    })),
+  }))
+
+  const organizations = {
+    select: vi.fn((columns: string) => ({
+      eq: vi.fn((column: string) => {
+        if (columns === 'id' && column === 'parent_org_id') {
+          return {
+            limit: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: childClient, error: null }),
+            })),
+          }
+        }
+
+        if (columns === 'id' && column === 'type') {
+          return {
+            limit: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: mainOrganization, error: null }),
+            })),
+          }
+        }
+
+        return {
+          maybeSingle: vi.fn().mockResolvedValue({ data: client, error: clientError }),
+        }
+      }),
+    })),
+    update: updateOrganization,
+  }
+
+  return {
+    updateOrganization,
+    client: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: authenticated ? { id: 'admin-user' } : null },
+          error: null,
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: authenticated ? { role } : null,
+                  error: null,
+                }),
+              })),
+            })),
+          }
+        }
+
+        return organizations
+      }),
+    },
+  }
+}
+
+async function patchClient(body: unknown, id = clientId) {
+  return PATCH(
+    new NextRequest(`http://localhost/api/admin/clients/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  )
+}
+
+async function deleteClient(id = clientId) {
+  return DELETE(
+    new NextRequest(`http://localhost/api/admin/clients/${id}`, { method: 'DELETE' }),
+    { params: Promise.resolve({ id }) },
+  )
+}
+
+describe('admin client management API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects invalid client IDs before accessing the database', async () => {
+    const response = await patchClient({ type: 'partner' }, 'not-a-uuid')
+
+    expect(response.status).toBe(400)
+    expect(createServerSupabaseClientMock).not.toHaveBeenCalled()
+  })
+
+  it('allows only super admins to change a client role', async () => {
+    const fixture = createSupabaseFixture({ role: 'staff' })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await patchClient({ type: 'partner' })
+
+    expect(response.status).toBe(403)
+    expect(fixture.updateOrganization).not.toHaveBeenCalled()
+  })
+
+  it('promotes a standard client to a white-label partner and audits the change', async () => {
+    const updatedClient = {
+      ...defaultClient,
+      type: 'partner',
+      parent_org_id: mainOrgId,
+    }
+    const fixture = createSupabaseFixture({ updatedClient })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await patchClient({ type: 'partner' })
+
+    expect(response.status).toBe(200)
+    expect(fixture.updateOrganization).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'partner', parent_org_id: mainOrgId }),
+    )
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'client_role_updated',
+        entity_id: clientId,
+        old_values: expect.objectContaining({ type: 'client' }),
+        new_values: expect.objectContaining({ type: 'partner' }),
+      }),
+    )
+  })
+
+  it('blocks disabling white-label access while the partner owns child clients', async () => {
+    const fixture = createSupabaseFixture({
+      client: { ...defaultClient, type: 'partner' },
+      childClient: { id: '89f04a30-7d6b-4e65-9e19-18cb95615e8b' },
+    })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await patchClient({ type: 'client' })
+
+    expect(response.status).toBe(409)
+    expect(fixture.updateOrganization).not.toHaveBeenCalled()
+  })
+
+  it('protects the main organization from role changes and deletion', async () => {
+    const fixture = createSupabaseFixture({
+      client: { ...defaultClient, type: 'kre8ivtech' },
+    })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const patchResponse = await patchClient({ type: 'client' })
+    const deleteResponse = await deleteClient()
+
+    expect(patchResponse.status).toBe(409)
+    expect(deleteResponse.status).toBe(409)
+    expect(fixture.updateOrganization).not.toHaveBeenCalled()
+  })
+
+  it('blocks deleting a white-label partner that still owns child clients', async () => {
+    const fixture = createSupabaseFixture({
+      client: { ...defaultClient, type: 'partner' },
+      childClient: { id: '89f04a30-7d6b-4e65-9e19-18cb95615e8b' },
+    })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteClient()
+
+    expect(response.status).toBe(409)
+    expect(fixture.updateOrganization).not.toHaveBeenCalled()
+  })
+
+  it('deactivates a client and records an audit event instead of destroying history', async () => {
+    const fixture = createSupabaseFixture({
+      updatedClient: { id: clientId, status: 'inactive' },
+    })
+    createServerSupabaseClientMock.mockResolvedValue(fixture.client as never)
+
+    const response = await deleteClient()
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ success: true, deletedId: clientId })
+    expect(fixture.updateOrganization).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'inactive' }),
+    )
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'client_deleted',
+        entity_id: clientId,
+        new_values: { status: 'inactive' },
+        details: { deletion_mode: 'deactivated_to_preserve_history' },
+      }),
+    )
+  })
+})

--- a/tests/unit/clients/ClientAdminControls.test.tsx
+++ b/tests/unit/clients/ClientAdminControls.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ClientAdminControls } from '@/components/clients/ClientAdminControls'
+
+const { push, refresh, toast } = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+  toast: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, refresh }),
+}))
+
+vi.mock('@/components/ui/use-toast', () => ({ toast }))
+
+const clientId = '31784cdf-469c-4936-9219-34be1fe7fbc5'
+
+describe('ClientAdminControls', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+    window.HTMLElement.prototype.hasPointerCapture = vi.fn(() => false)
+    window.HTMLElement.prototype.releasePointerCapture = vi.fn()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('changes a standard client to a white-label partner', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ success: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <ClientAdminControls
+        clientId={clientId}
+        clientName="Acme Co"
+        initialType="client"
+        status="active"
+      />,
+    )
+
+    const roleSelect = screen.getByRole('combobox', { name: 'Client role' })
+    fireEvent.keyDown(roleSelect, { key: 'ArrowDown' })
+    fireEvent.click(await screen.findByRole('option', { name: 'White-label partner' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save role' }))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(`/api/admin/clients/${clientId}`, {
+        method: 'PATCH',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'partner' }),
+      }),
+    )
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(toast).toHaveBeenCalledWith({
+      title: 'Client role updated',
+      description: 'Acme Co is now a white-label partner.',
+    })
+  })
+
+  it('confirms and deactivates a client while preserving history', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ success: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <ClientAdminControls
+        clientId={clientId}
+        clientName="Acme Co"
+        initialType="client"
+        status="active"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete client' }))
+    expect(screen.getByText('Delete Acme Co?')).toBeInTheDocument()
+    expect(screen.getByText(/invoices, contracts, tickets, files, and audit history are preserved/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete client' }))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(`/api/admin/clients/${clientId}`, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      }),
+    )
+    expect(push).toHaveBeenCalledWith('/dashboard/clients')
+    expect(refresh).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the confirmation open and shows deletion errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: vi.fn().mockResolvedValue({ error: 'Client could not be deleted' }),
+      }),
+    )
+
+    render(
+      <ClientAdminControls
+        clientId={clientId}
+        clientName="Acme Co"
+        initialType="client"
+        status="active"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete client' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete client' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Client could not be deleted')
+    expect(screen.getByText('Delete Acme Co?')).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not offer deletion again for inactive clients', () => {
+    render(
+      <ClientAdminControls
+        clientId={clientId}
+        clientName="Acme Co"
+        initialType="client"
+        status="inactive"
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Client deleted' })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary
- add super-admin controls to switch organizations between standard client and white-label partner
- add confirmed client deletion using safe deactivation so invoices, contracts, tickets, files, and audit history remain intact
- protect the main organization and partner/child hierarchy, close the generic organization type-update bypass, and audit both actions

## Validation
- `npx vitest run tests/unit/api/admin-client-management.test.ts tests/unit/clients/ClientAdminControls.test.tsx` (11 tests)
- `npm test -- --run` (76 tests)
- `npm run type-check`
- `npm run lint` (passes with 13 existing warnings)
- `npm run build:local`
- `ai-trust-scan --pre-commit` (clean)