### PR TITLE
feat(settings): add partner white-label setup guide

### DIFF
--- a/src/app/dashboard/settings/white-label/page.tsx
+++ b/src/app/dashboard/settings/white-label/page.tsx
@@ -3,7 +3,9 @@ import { PortalBrandingForm } from "@/components/settings/portal-branding-form";
 import { OrganizationBrandingForm } from "@/components/settings/organization-branding-form";
 import { WhiteLabelAdminSection } from "@/components/settings/white-label-admin-section";
 import { SmtpConfigForm } from "@/components/settings/smtp-config-form";
+import { WhiteLabelSetupGuide } from "@/components/settings/WhiteLabelSetupGuide";
 import { getPortalBranding } from "@/lib/actions/portal-branding";
+import { getExpectedCnameTargets } from "@/lib/white-label/domain-verification";
 import { redirect } from "next/navigation";
 
 export default async function WhiteLabelSettingsPage() {
@@ -89,6 +91,7 @@ export default async function WhiteLabelSettingsPage() {
   }
 
   const portalBranding = isSuperAdmin ? await getPortalBranding() : null;
+  const cnameTarget = getExpectedCnameTargets()[0] ?? "clients.kre8ivtech.com";
 
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -111,16 +114,23 @@ export default async function WhiteLabelSettingsPage() {
         {/* Organization branding - partners can edit their own branding */}
         {isPartnerOrPartnerStaff && organization && (
           <>
-            <OrganizationBrandingForm
-              organization={organization}
-              canEdit={true}
-            />
             {organization.type === "partner" && (
-              <SmtpConfigForm
-                endpoint={`/api/organizations/${organization.id}/smtp`}
-                title="Your Organization SMTP"
-                description="Set your own SMTP provider for white-label outbound emails to your clients."
+              <WhiteLabelSetupGuide organization={organization} cnameTarget={cnameTarget} />
+            )}
+            <div id="white-label-branding" className="scroll-mt-6">
+              <OrganizationBrandingForm
+                organization={organization}
+                canEdit={true}
               />
+            </div>
+            {organization.type === "partner" && (
+              <div id="white-label-email" className="scroll-mt-6">
+                <SmtpConfigForm
+                  endpoint={`/api/organizations/${organization.id}/smtp`}
+                  title="Your Organization SMTP"
+                  description="Set your own SMTP provider for white-label outbound emails to your clients."
+                />
+              </div>
             )}
           </>
         )}

--- a/src/components/settings/WhiteLabelSetupGuide.tsx
+++ b/src/components/settings/WhiteLabelSetupGuide.tsx
@@ -1,0 +1,177 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { ArrowRight, Check, Globe2, Mail, Palette, Rocket } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { cn } from '@/lib/utils'
+
+type WhiteLabelSetupGuideProps = {
+  organization: {
+    custom_domain?: string | null
+    custom_domain_verified?: boolean | null
+    branding_config?: {
+      app_name?: string | null
+      logo_url?: string | null
+      primary_color?: string | null
+    } | null
+  }
+  cnameTarget: string
+}
+
+type SetupStep = {
+  title: string
+  description: string
+  href: string
+  action: string
+  complete: boolean
+  icon: typeof Palette
+  detail?: ReactNode
+}
+
+export function WhiteLabelSetupGuide({
+  organization,
+  cnameTarget,
+}: WhiteLabelSetupGuideProps) {
+  const branding = organization.branding_config ?? {}
+  const brandingComplete = Boolean(
+    branding.app_name?.trim() && branding.logo_url?.trim() && branding.primary_color?.trim(),
+  )
+  const domainConnected = Boolean(organization.custom_domain?.trim())
+  const domainVerified = Boolean(organization.custom_domain_verified)
+
+  const steps: SetupStep[] = [
+    {
+      title: 'Create your portal identity',
+      description:
+        'Add a portal name, hosted logo URL, and primary brand color. You can also customize the tagline and login background.',
+      href: '#white-label-branding',
+      action: 'Open branding',
+      complete: brandingComplete,
+      icon: Palette,
+    },
+    {
+      title: 'Connect your custom domain',
+      description:
+        'Choose a portal subdomain, add the CNAME record with your DNS provider, then save the domain below.',
+      href: '#white-label-domain',
+      action: 'Open domain setup',
+      complete: domainConnected,
+      icon: Globe2,
+      detail: (
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <code className="rounded-md bg-muted px-2 py-1 text-foreground">
+            portal.yourdomain.com
+          </code>
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          <code className="rounded-md bg-muted px-2 py-1 text-foreground">{cnameTarget}</code>
+        </div>
+      ),
+    },
+    {
+      title: 'Verify and launch',
+      description:
+        'After DNS has propagated, select Verify now. Once verified, open your custom domain in a private browser window and test sign-in on desktop and mobile.',
+      href: '#white-label-domain',
+      action: domainVerified ? 'Review launch settings' : 'Verify domain',
+      complete: domainVerified,
+      icon: Rocket,
+    },
+  ]
+
+  const completedSteps = steps.filter((step) => step.complete).length
+  const progress = Math.round((completedSteps / steps.length) * 100)
+
+  return (
+    <Card className="overflow-hidden border-border shadow-sm">
+      <CardHeader className="gap-4 border-b bg-muted/30 sm:flex-row sm:items-end sm:justify-between sm:space-y-0">
+        <div className="space-y-1.5">
+          <CardTitle className="text-xl">White-label launch checklist</CardTitle>
+          <CardDescription className="max-w-2xl">
+            Complete these steps to publish a branded portal on your own domain. Most setups take
+            about 15 minutes, plus DNS propagation time.
+          </CardDescription>
+        </div>
+        <Badge variant={completedSteps === steps.length ? 'success' : 'secondary'}>
+          {completedSteps} of {steps.length} ready
+        </Badge>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="border-b px-6 py-4">
+          <div className="mb-2 flex items-center justify-between gap-4 text-sm">
+            <span className="font-medium text-foreground">Setup progress</span>
+            <span className="text-muted-foreground">{progress}%</span>
+          </div>
+          <Progress
+            value={progress}
+            className="h-2"
+            aria-label={`${completedSteps} of ${steps.length} white-label setup steps complete`}
+          />
+        </div>
+
+        <ol className="divide-y">
+          {steps.map((step, index) => {
+            const Icon = step.icon
+
+            return (
+              <li key={step.title} className="px-6 py-5">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+                  <div
+                    className={cn(
+                      'flex h-9 w-9 shrink-0 items-center justify-center rounded-full border text-sm font-semibold',
+                      step.complete
+                        ? 'border-success bg-success text-success-foreground'
+                        : 'border-border bg-background text-muted-foreground',
+                    )}
+                    aria-hidden="true"
+                  >
+                    {step.complete ? <Check className="h-4 w-4" /> : index + 1}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                      <h3 className="font-semibold text-foreground">{step.title}</h3>
+                      <Badge variant={step.complete ? 'success' : 'outline'}>
+                        {step.complete ? 'Complete' : 'Next step'}
+                      </Badge>
+                    </div>
+                    <p className="mt-1.5 max-w-3xl text-sm leading-6 text-muted-foreground">
+                      {step.description}
+                    </p>
+                    {step.detail}
+                  </div>
+                  <Button asChild variant="outline" size="sm" className="shrink-0 sm:mt-0.5">
+                    <Link href={step.href}>
+                      {step.action}
+                      <ArrowRight aria-hidden="true" />
+                    </Link>
+                  </Button>
+                </div>
+              </li>
+            )
+          })}
+        </ol>
+
+        <div className="flex flex-col gap-3 border-t bg-muted/20 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <Mail className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+            <div>
+              <p className="font-medium text-foreground">Optional: send email from your brand</p>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Add your SMTP provider after launch so portal notifications use your sender name
+                and address.
+              </p>
+            </div>
+          </div>
+          <Button asChild variant="ghost" size="sm" className="self-start sm:self-auto">
+            <Link href="#white-label-email">
+              Configure email
+              <ArrowRight aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/settings/organization-branding-form.tsx
+++ b/src/components/settings/organization-branding-form.tsx
@@ -42,11 +42,11 @@ export function OrganizationBrandingForm({ organization, canEdit, canManageDomai
 
   const cnameTarget = useMemo(() => {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-    if (!appUrl) return "app.ktportal.app";
+    if (!appUrl) return "clients.kre8ivtech.com";
     try {
       return new URL(appUrl).hostname;
     } catch {
-      return appUrl.replace(/^https?:\/\//, "").split("/")[0] || "app.ktportal.app";
+      return appUrl.replace(/^https?:\/\//, "").split("/")[0] || "clients.kre8ivtech.com";
     }
   }, []);
 
@@ -269,7 +269,7 @@ export function OrganizationBrandingForm({ organization, canEdit, canManageDomai
           </div>
 
           {organization.type === "partner" && (
-            <div className="space-y-4 rounded-lg border border-border p-4">
+            <div id="white-label-domain" className="scroll-mt-6 space-y-4 rounded-lg border border-border p-4">
               <div className="rounded-md border border-info/30 bg-info/10 p-3">
                 <div className="flex items-start gap-2">
                   <Globe2 className="mt-0.5 h-4 w-4 text-info" />

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -15,6 +15,7 @@ const Progress = React.forwardRef<
       "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
       className
     )}
+    value={value}
     {...props}
   >
     <ProgressPrimitive.Indicator

--- a/tests/unit/settings/WhiteLabelSetupGuide.test.tsx
+++ b/tests/unit/settings/WhiteLabelSetupGuide.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { WhiteLabelSetupGuide } from '@/components/settings/WhiteLabelSetupGuide'
+
+describe('WhiteLabelSetupGuide', () => {
+  it('shows the ordered setup instructions and CNAME target', () => {
+    render(
+      <WhiteLabelSetupGuide
+        organization={{ branding_config: null, custom_domain: null }}
+        cnameTarget="clients.kre8ivtech.com"
+      />,
+    )
+
+    expect(screen.getByText('White-label launch checklist')).toBeInTheDocument()
+    expect(screen.getByText('Create your portal identity')).toBeInTheDocument()
+    expect(screen.getByText('Connect your custom domain')).toBeInTheDocument()
+    expect(screen.getByText('Verify and launch')).toBeInTheDocument()
+    expect(screen.getByText('clients.kre8ivtech.com')).toBeInTheDocument()
+    expect(screen.getByText('Optional: send email from your brand')).toBeInTheDocument()
+    expect(screen.getByText('0 of 3 ready')).toBeInTheDocument()
+  })
+
+  it('derives completion from saved branding and domain settings', () => {
+    render(
+      <WhiteLabelSetupGuide
+        organization={{
+          branding_config: {
+            app_name: 'Acme Portal',
+            logo_url: 'https://example.com/logo.svg',
+            primary_color: '#155eef',
+          },
+          custom_domain: 'portal.acme.com',
+          custom_domain_verified: true,
+        }}
+        cnameTarget="clients.kre8ivtech.com"
+      />,
+    )
+
+    expect(screen.getByText('3 of 3 ready')).toBeInTheDocument()
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(screen.getAllByText('Complete')).toHaveLength(3)
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100')
+  })
+
+  it('requires the core identity fields before marking branding complete', () => {
+    render(
+      <WhiteLabelSetupGuide
+        organization={{
+          branding_config: { app_name: 'Acme Portal', primary_color: '#155eef' },
+          custom_domain: 'portal.acme.com',
+          custom_domain_verified: false,
+        }}
+        cnameTarget="clients.kre8ivtech.com"
+      />,
+    )
+
+    expect(screen.getByText('1 of 3 ready')).toBeInTheDocument()
+    expect(screen.getAllByText('Next step')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add a partner-facing, status-aware white-label launch checklist
- guide partners through branding, CNAME setup, domain verification, launch testing, and optional SMTP
- link every checklist action directly to the live settings section and show completion from saved organization data
- correct the production CNAME fallback and expose progress values to assistive technology

## Validation
- `npx vitest run tests/unit/settings/WhiteLabelSetupGuide.test.tsx` (3 tests)
- `npm test -- --run` (80 tests)
- `npm run type-check`
- `npm run lint` (passes with 13 existing warnings)
- `npm run build:local`
- Impeccable detector (no findings)
- `ai-trust-scan --pre-commit` (clean)